### PR TITLE
Add directory and keygen commands

### DIFF
--- a/cmd/directory/e2e_test.go
+++ b/cmd/directory/e2e_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestDirectoryServer(t *testing.T) {
+	data := Directory{
+		Relays: map[string]RelayInfo{
+			"r1": {Endpoint: "127.0.0.1:5000", PubKey: "pk"},
+		},
+		HiddenServices: map[string]HiddenServiceInfo{
+			"h1": {Relay: "r1", PubKey: "hpk"},
+		},
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "dir.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if err := json.NewEncoder(tmp).Encode(data); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+
+	dir, err := loadDirectory(tmp.Name())
+	if err != nil {
+		t.Fatalf("loadDirectory: %v", err)
+	}
+
+	srv := httptest.NewServer(handler(dir))
+	defer srv.Close()
+
+	res, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http get: %v", err)
+	}
+	defer res.Body.Close()
+
+	var got Directory
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Relays["r1"].Endpoint != "127.0.0.1:5000" {
+		t.Errorf("relay endpoint mismatch")
+	}
+	if got.HiddenServices["h1"].Relay != "r1" {
+		t.Errorf("hidden relay mismatch")
+	}
+}

--- a/cmd/directory/main.go
+++ b/cmd/directory/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+)
+
+type Directory struct {
+	Relays         map[string]RelayInfo         `json:"relays"`
+	HiddenServices map[string]HiddenServiceInfo `json:"hidden_services"`
+}
+
+type RelayInfo struct {
+	Endpoint string `json:"endpoint"`
+	PubKey   string `json:"pubkey"`
+}
+
+type HiddenServiceInfo struct {
+	Relay  string `json:"relay"`
+	PubKey string `json:"pubkey"`
+}
+
+func loadDirectory(path string) (Directory, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Directory{}, err
+	}
+	var d Directory
+	if err := json.Unmarshal(b, &d); err != nil {
+		return Directory{}, err
+	}
+	return d, nil
+}
+
+func handler(d Directory) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(d)
+	})
+}
+
+func main() {
+	data := flag.String("data", "directory.json", "directory json file")
+	listen := flag.String("listen", ":8081", "listen address")
+	flag.Parse()
+
+	dir, err := loadDirectory(*data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("directory server listening on", *listen)
+	log.Fatal(http.ListenAndServe(*listen, handler(dir)))
+}

--- a/cmd/keygen/e2e_test.go
+++ b/cmd/keygen/e2e_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/pem"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeygenCommand(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "key.pem")
+
+	cmd := exec.Command("go", "run", "./cmd/keygen", "-out", out)
+	cmd.Dir = "../.."
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run command: %v, output: %s", err, b)
+	}
+
+	privData, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read priv: %v", err)
+	}
+	blk, _ := pem.Decode(privData)
+	if blk == nil || blk.Type != "RSA PRIVATE KEY" {
+		t.Errorf("invalid private key")
+	}
+
+	pubData, err := os.ReadFile(out + ".pub")
+	if err != nil {
+		t.Fatalf("read pub: %v", err)
+	}
+	blk, _ = pem.Decode(pubData)
+	if blk == nil || blk.Type != "RSA PUBLIC KEY" {
+		t.Errorf("invalid public key")
+	}
+}

--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+func saveRSAPriv(path string, key *rsa.PrivateKey) error {
+	b := x509.MarshalPKCS1PrivateKey(key)
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: b})
+	return os.WriteFile(path, pemData, 0600)
+}
+
+func saveRSAPub(path string, key *rsa.PublicKey) error {
+	b := x509.MarshalPKCS1PublicKey(key)
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: b})
+	return os.WriteFile(path, pemData, 0644)
+}
+
+func main() {
+	out := flag.String("out", "rsa_key.pem", "output private key file")
+	flag.Parse()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := saveRSAPriv(*out, key); err != nil {
+		log.Fatal(err)
+	}
+	pubOut := *out + ".pub"
+	if err := saveRSAPub(pubOut, &key.PublicKey); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("generated", *out, "and", pubOut)
+}


### PR DESCRIPTION
## Summary
- implement new `ptor-dir` command for serving relay/hidden service information
- implement `ptor-keygen` command that creates RSA key pairs
- add e2e tests for directory server and key generation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685623e0bd38832bb22ceb233f842a29