### PR TITLE
Improve tests with error returns and table-driven style

### DIFF
--- a/cmd/hidden/main_test.go
+++ b/cmd/hidden/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ed25519"
 	"encoding/pem"
+	"io"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -37,7 +38,10 @@ func TestDemoMux(t *testing.T) {
 	}
 	defer res.Body.Close()
 	buf := make([]byte, 32)
-	n, _ := res.Body.Read(buf)
+	n, err := res.Body.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read body: %v", err)
+	}
 	if string(buf[:n]) != "hello from hidden service" {
 		t.Errorf("unexpected body: %q", buf[:n])
 	}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -59,8 +59,14 @@ func readCell(r io.Reader) (simpleCell, error) {
 	}
 	var id uuid.UUID
 	copy(id[:], hdrBuf[:16])
-	cid, _ := value_object.CircuitIDFrom(id.String())
-	sid, _ := value_object.StreamIDFrom(binary.BigEndian.Uint16(hdrBuf[16:18]))
+	cid, err := value_object.CircuitIDFrom(id.String())
+	if err != nil {
+		return simpleCell{}, err
+	}
+	sid, err := value_object.StreamIDFrom(binary.BigEndian.Uint16(hdrBuf[16:18]))
+	if err != nil {
+		return simpleCell{}, err
+	}
 	l := binary.BigEndian.Uint16(hdrBuf[18:20])
 	if l == 0xFFFF {
 		return simpleCell{circID: cid, streamID: sid, end: true}, nil

--- a/internal/domain/entity/circuit_test.go
+++ b/internal/domain/entity/circuit_test.go
@@ -7,10 +7,22 @@ import (
 )
 
 func TestNewCircuit_Table(t *testing.T) {
-	id, _ := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	key, _ := value_object.AESKeyFrom(make([]byte, 32))
-	nonce, _ := value_object.NonceFrom(make([]byte, 12))
+	id, err := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("CircuitIDFrom: %v", err)
+	}
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("NewRelayID: %v", err)
+	}
+	key, err := value_object.AESKeyFrom(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("AESKeyFrom: %v", err)
+	}
+	nonce, err := value_object.NonceFrom(make([]byte, 12))
+	if err != nil {
+		t.Fatalf("NonceFrom: %v", err)
+	}
 	tests := []struct {
 		name       string
 		relays     []value_object.RelayID
@@ -39,23 +51,47 @@ func TestNewCircuit_Table(t *testing.T) {
 }
 
 func TestCircuit_StreamManagement(t *testing.T) {
-	id, _ := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	key, _ := value_object.AESKeyFrom(make([]byte, 32))
-	nonce, _ := value_object.NonceFrom(make([]byte, 12))
-	c, _ := entity.NewCircuit(id, []value_object.RelayID{relayID, relayID, relayID}, []value_object.AESKey{key, key, key}, []value_object.Nonce{nonce, nonce, nonce})
-	st, err := c.OpenStream()
+	id, err := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
 	if err != nil {
-		t.Fatalf("OpenStream error: %v", err)
+		t.Fatalf("CircuitIDFrom: %v", err)
 	}
-	if st.Closed {
-		t.Errorf("stream should be open")
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("NewRelayID: %v", err)
 	}
-	c.CloseStream(st.ID)
-	if !st.Closed {
-		t.Errorf("stream should be closed")
+	key, err := value_object.AESKeyFrom(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("AESKeyFrom: %v", err)
 	}
-	if len(c.ActiveStreams()) != 0 {
-		t.Errorf("no active streams expected")
+	nonce, err := value_object.NonceFrom(make([]byte, 12))
+	if err != nil {
+		t.Fatalf("NonceFrom: %v", err)
+	}
+
+	tests := []struct {
+		name string
+	}{{"open close"}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := entity.NewCircuit(id, []value_object.RelayID{relayID, relayID, relayID}, []value_object.AESKey{key, key, key}, []value_object.Nonce{nonce, nonce, nonce})
+			if err != nil {
+				t.Fatalf("NewCircuit: %v", err)
+			}
+			st, err := c.OpenStream()
+			if err != nil {
+				t.Fatalf("OpenStream error: %v", err)
+			}
+			if st.Closed {
+				t.Errorf("stream should be open")
+			}
+			c.CloseStream(st.ID)
+			if !st.Closed {
+				t.Errorf("stream should be closed")
+			}
+			if len(c.ActiveStreams()) != 0 {
+				t.Errorf("no active streams expected")
+			}
+		})
 	}
 }

--- a/internal/domain/entity/relay_test.go
+++ b/internal/domain/entity/relay_test.go
@@ -10,39 +10,82 @@ import (
 	"testing"
 )
 
-func makeTestRelay() *entity.Relay {
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	pkix, _ := rsa.GenerateKey(rand.Reader, 2048)
+func makeTestRelay() (*entity.Relay, error) {
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	pkix, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
 	pub := &pkix.PublicKey
-	pkixBytes, _ := x509.MarshalPKIXPublicKey(pub)
+	pkixBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkixBytes})
-	rsaPub, _ := value_object.RSAPubKeyFromPEM(pemBytes)
-	end, _ := value_object.NewEndpoint("127.0.0.1", 5000)
-	return entity.NewRelay(relayID, end, rsaPub)
+	rsaPub, err := value_object.RSAPubKeyFromPEM(pemBytes)
+	if err != nil {
+		return nil, err
+	}
+	end, err := value_object.NewEndpoint("127.0.0.1", 5000)
+	if err != nil {
+		return nil, err
+	}
+	return entity.NewRelay(relayID, end, rsaPub), nil
 }
 
 func TestRelay_Basic(t *testing.T) {
-	r := makeTestRelay()
-	if r.Status() != entity.Offline {
-		t.Errorf("expected Offline")
+	relay, err := makeTestRelay()
+	if err != nil {
+		t.Fatalf("setup relay: %v", err)
 	}
-	r.SetOnline()
-	if r.Status() != entity.Online {
-		t.Errorf("expected Online")
+
+	tests := []struct {
+		name   string
+		action func()
+		want   entity.RelayStatus
+	}{
+		{"initial", func() {}, entity.Offline},
+		{"online", relay.SetOnline, entity.Online},
+		{"offline", relay.SetOffline, entity.Offline},
 	}
-	r.SetOffline()
-	if r.Status() != entity.Offline {
-		t.Errorf("expected Offline after SetOffline")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.action()
+			if relay.Status() != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, relay.Status())
+			}
+		})
 	}
 }
 
 func TestRelay_Stats(t *testing.T) {
-	r := makeTestRelay()
-	r.IncSuccess()
-	r.IncSuccess()
-	r.IncFailure()
-	succ, fail := r.Stats()
-	if succ != 2 || fail != 1 {
-		t.Errorf("expected 2 success, 1 failure, got %d %d", succ, fail)
+	relay, err := makeTestRelay()
+	if err != nil {
+		t.Fatalf("setup relay: %v", err)
+	}
+
+	relay.IncSuccess()
+	relay.IncSuccess()
+	relay.IncFailure()
+
+	tests := []struct {
+		name     string
+		wantSucc uint64
+		wantFail uint64
+	}{
+		{"stats", 2, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			succ, fail := relay.Stats()
+			if succ != tt.wantSucc || fail != tt.wantFail {
+				t.Errorf("expected %d success, %d failure, got %d %d", tt.wantSucc, tt.wantFail, succ, fail)
+			}
+		})
 	}
 }

--- a/internal/domain/value_object/hidden_addr_test.go
+++ b/internal/domain/value_object/hidden_addr_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestHiddenAddr_Table(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
 	tests := []struct {
 		name string
 		pub  ed25519.PublicKey

--- a/internal/domain/value_object/rsa_pubkey.go
+++ b/internal/domain/value_object/rsa_pubkey.go
@@ -22,7 +22,7 @@ func RSAPubKeyFromPEM(pemBytes []byte) (RSAPubKey, error) {
 	if !ok {
 		return RSAPubKey{}, errors.New("not RSA key")
 	}
-	return RSAPubKey{rsaPub}, nil
+	return RSAPubKey{PublicKey: rsaPub}, nil
 }
 
 func (k RSAPubKey) ToPEM() []byte {

--- a/internal/domain/value_object/rsa_pubkey_test.go
+++ b/internal/domain/value_object/rsa_pubkey_test.go
@@ -10,9 +10,15 @@ import (
 )
 
 func TestRSAPubKey_Table(t *testing.T) {
-	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
 	pub := &key.PublicKey
-	pkixBytes, _ := x509.MarshalPKIXPublicKey(pub)
+	pkixBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal pkix: %v", err)
+	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkixBytes})
 	tests := []struct {
 		name       string

--- a/internal/usecase/build_circuit_usecase_test.go
+++ b/internal/usecase/build_circuit_usecase_test.go
@@ -18,13 +18,17 @@ func (m *mockBuildService) Build(hops int) (*entity.Circuit, error) {
 }
 
 func TestBuildCircuitUseCase_Handle_Table(t *testing.T) {
+	circuit, err := makeTestCircuit()
+	if err != nil {
+		t.Fatalf("setup circuit: %v", err)
+	}
 	tests := []struct {
 		name       string
 		circuit    *entity.Circuit
 		err        error
 		expectsErr bool
 	}{
-		{"ok", makeTestCircuit(), nil, false},
+		{"ok", circuit, nil, false},
 		{"error", nil, errors.New("fail"), true},
 	}
 	for _, tt := range tests {

--- a/internal/usecase/close_stream_usecase_test.go
+++ b/internal/usecase/close_stream_usecase_test.go
@@ -35,8 +35,14 @@ func (m *mockTransmitterClose) SendData(c value_object.CircuitID, s value_object
 }
 
 func TestCloseStreamInteractor_Handle(t *testing.T) {
-	circuit := makeTestCircuit()
-	st, _ := circuit.OpenStream()
+	circuit, err := makeTestCircuit()
+	if err != nil {
+		t.Fatalf("setup circuit: %v", err)
+	}
+	st, err := circuit.OpenStream()
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
 
 	tests := []struct {
 		name       string

--- a/internal/usecase/open_stream_usecase_test.go
+++ b/internal/usecase/open_stream_usecase_test.go
@@ -22,17 +22,35 @@ func (m *mockCircuitRepoOpen) Save(*entity.Circuit) error             { return n
 func (m *mockCircuitRepoOpen) Delete(value_object.CircuitID) error    { return nil }
 func (m *mockCircuitRepoOpen) ListActive() ([]*entity.Circuit, error) { return nil, nil }
 
-func makeTestCircuit() *entity.Circuit {
-	id, _ := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	key, _ := value_object.NewAESKey()
-	nonce, _ := value_object.NewNonce()
-	c, _ := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
-	return c
+func makeTestCircuit() (*entity.Circuit, error) {
+	id, err := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	key, err := value_object.NewAESKey()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := value_object.NewNonce()
+	if err != nil {
+		return nil, err
+	}
+	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func TestOpenStreamInteractor_Handle(t *testing.T) {
-	circuit := makeTestCircuit()
+	circuit, err := makeTestCircuit()
+	if err != nil {
+		t.Fatalf("setup circuit: %v", err)
+	}
 
 	tests := []struct {
 		name       string

--- a/internal/usecase/send_data_usecase_test.go
+++ b/internal/usecase/send_data_usecase_test.go
@@ -35,8 +35,14 @@ func (m *mockTransmitterSend) SendEnd(c value_object.CircuitID, s value_object.S
 }
 
 func TestSendDataInteractor_Handle(t *testing.T) {
-	circuit := makeTestCircuit()
-	st, _ := circuit.OpenStream()
+	circuit, err := makeTestCircuit()
+	if err != nil {
+		t.Fatalf("setup circuit: %v", err)
+	}
+	st, err := circuit.OpenStream()
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
 
 	tests := []struct {
 		name       string

--- a/internal/usecase/service/circuit_build_service.go
+++ b/internal/usecase/service/circuit_build_service.go
@@ -57,10 +57,16 @@ func (b *circuitBuildServiceImpl) Build(hops int) (*entity.Circuit, error) {
 	for _, r := range selected {
 		relayIDs = append(relayIDs, r.ID())
 
-		k, _ := value_object.NewAESKey() // 32B ランダム
+		k, err := value_object.NewAESKey() // 32B ランダム
+		if err != nil {
+			return nil, fmt.Errorf("generate AES key: %w", err)
+		}
 		keys = append(keys, k)
 
-		n, _ := value_object.NewNonce() // 12B ランダム
+		n, err := value_object.NewNonce() // 12B ランダム
+		if err != nil {
+			return nil, fmt.Errorf("generate nonce: %w", err)
+		}
 		nonces = append(nonces, n)
 	}
 

--- a/internal/usecase/service/circuit_build_service_test.go
+++ b/internal/usecase/service/circuit_build_service_test.go
@@ -39,19 +39,37 @@ func (m *mockCircuitRepo) Find(_ value_object.CircuitID) (*entity.Circuit, error
 func (m *mockCircuitRepo) Delete(_ value_object.CircuitID) error                  { return nil }
 func (m *mockCircuitRepo) ListActive() ([]*entity.Circuit, error)                 { return nil, nil }
 
-func makeTestRelay() *entity.Relay {
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	pkix, _ := rsa.GenerateKey(rand.Reader, 2048)
+func makeTestRelay() (*entity.Relay, error) {
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	pkix, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
 	pub := &pkix.PublicKey
-	pkixBytes, _ := x509.MarshalPKIXPublicKey(pub)
+	pkixBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkixBytes})
-	rsaPub, _ := value_object.RSAPubKeyFromPEM(pemBytes)
-	end, _ := value_object.NewEndpoint("127.0.0.1", 5000)
-	return entity.NewRelay(relayID, end, rsaPub)
+	rsaPub, err := value_object.RSAPubKeyFromPEM(pemBytes)
+	if err != nil {
+		return nil, err
+	}
+	end, err := value_object.NewEndpoint("127.0.0.1", 5000)
+	if err != nil {
+		return nil, err
+	}
+	return entity.NewRelay(relayID, end, rsaPub), nil
 }
 
 func TestCircuitBuildService_Build_Table(t *testing.T) {
-	relay := makeTestRelay()
+	relay, err := makeTestRelay()
+	if err != nil {
+		t.Fatalf("setup relay: %v", err)
+	}
 	tests := []struct {
 		name       string
 		online     []*entity.Relay

--- a/internal/usecase/shutdown_circuit_usecase_test.go
+++ b/internal/usecase/shutdown_circuit_usecase_test.go
@@ -44,21 +44,41 @@ func (m *mockTransmitterShutdown) SendData(c value_object.CircuitID, s value_obj
 	return nil
 }
 
-func makeTestCircuitShutdown() *entity.Circuit {
-	id, _ := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
-	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
-	key, _ := value_object.NewAESKey()
-	nonce, _ := value_object.NewNonce()
-	c, _ := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
-	st1, _ := c.OpenStream()
-	st2, _ := c.OpenStream()
-	_ = st1
-	_ = st2
-	return c
+func makeTestCircuitShutdown() (*entity.Circuit, error) {
+	id, err := value_object.CircuitIDFrom("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	relayID, err := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		return nil, err
+	}
+	key, err := value_object.NewAESKey()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := value_object.NewNonce()
+	if err != nil {
+		return nil, err
+	}
+	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	if err != nil {
+		return nil, err
+	}
+	if _, err := c.OpenStream(); err != nil {
+		return nil, err
+	}
+	if _, err := c.OpenStream(); err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func TestShutdownCircuitInteractor_Handle(t *testing.T) {
-	circuit := makeTestCircuitShutdown()
+	circuit, err := makeTestCircuitShutdown()
+	if err != nil {
+		t.Fatalf("setup circuit: %v", err)
+	}
 	cid := circuit.ID().String()
 
 	t.Run("ok", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- refactor helper functions to return errors
- convert remaining tests to table-driven form
- update callers to handle errors explicitly

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68566f3f27c0832b9d0a748716e51345