### PR TITLE
Refactor crypto and cell packages

### DIFF
--- a/internal/domain/value_object/cell.go
+++ b/internal/domain/value_object/cell.go
@@ -1,0 +1,60 @@
+package value_object
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	Version byte = 0x01
+
+	CmdExtend  byte = 0x01
+	CmdConnect byte = 0x02
+	CmdData    byte = 0x03
+	CmdEnd     byte = 0x04
+	CmdDestroy byte = 0x05
+
+	MaxPayloadSize = MaxCellSize - headerOverhead
+)
+
+// Cell represents a 512-byte protocol cell.
+type Cell struct {
+	Cmd     byte
+	Version byte
+	Payload []byte
+}
+
+// Encode serializes the cell into a fixed 512-byte slice with random padding.
+func Encode(c Cell) ([]byte, error) {
+	if len(c.Payload) > MaxPayloadSize {
+		return nil, fmt.Errorf("payload too big: %d > %d", len(c.Payload), MaxPayloadSize)
+	}
+	buf := make([]byte, MaxCellSize)
+	buf[0] = c.Cmd
+	buf[1] = c.Version
+	binary.BigEndian.PutUint16(buf[2:], uint16(len(c.Payload)))
+	copy(buf[4:], c.Payload)
+	if _, err := rand.Read(buf[4+len(c.Payload):]); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// Decode parses a 512-byte buffer into a Cell struct.
+func Decode(buf []byte) (*Cell, error) {
+	if len(buf) != MaxCellSize {
+		return nil, fmt.Errorf("invalid cell length: %d", len(buf))
+	}
+	l := binary.BigEndian.Uint16(buf[2:4])
+	if l > MaxPayloadSize {
+		return nil, fmt.Errorf("invalid payload length: %d", l)
+	}
+	payload := make([]byte, l)
+	copy(payload, buf[4:4+int(l)])
+	return &Cell{
+		Cmd:     buf[0],
+		Version: buf[1],
+		Payload: payload,
+	}, nil
+}

--- a/internal/domain/value_object/cell_test.go
+++ b/internal/domain/value_object/cell_test.go
@@ -1,0 +1,26 @@
+package value_object_test
+
+import (
+	"testing"
+
+	valueobject "ikedadada/go-ptor/internal/domain/value_object"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	payload := []byte("hello")
+	c := valueobject.Cell{Cmd: valueobject.CmdData, Version: valueobject.Version, Payload: payload}
+	buf, err := valueobject.Encode(c)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(buf) != valueobject.MaxCellSize {
+		t.Fatalf("size: %d", len(buf))
+	}
+	d, err := valueobject.Decode(buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if d.Cmd != c.Cmd || d.Version != c.Version || string(d.Payload) != string(payload) {
+		t.Fatalf("mismatch")
+	}
+}

--- a/internal/infrastructure/crypto/crypto.go
+++ b/internal/infrastructure/crypto/crypto.go
@@ -1,0 +1,45 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+)
+
+// RSAEncrypt encrypts data using RSA-OAEP with SHA-256.
+func RSAEncrypt(pub *rsa.PublicKey, in []byte) ([]byte, error) {
+	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, in, nil)
+}
+
+// RSADecrypt decrypts data using RSA-OAEP with SHA-256.
+func RSADecrypt(priv *rsa.PrivateKey, in []byte) ([]byte, error) {
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, in, nil)
+}
+
+// AESSeal encrypts plaintext with AES-256-GCM.
+func AESSeal(key [32]byte, nonce [12]byte, plain []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nil, nonce[:], plain, nil), nil
+}
+
+// AESOpen decrypts ciphertext with AES-256-GCM.
+func AESOpen(key [32]byte, nonce [12]byte, enc []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return gcm.Open(nil, nonce[:], enc, nil)
+}

--- a/internal/infrastructure/crypto/crypto_test.go
+++ b/internal/infrastructure/crypto/crypto_test.go
@@ -1,0 +1,47 @@
+package crypto_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"ikedadada/go-ptor/internal/infrastructure/crypto"
+)
+
+func TestAESRoundTrip(t *testing.T) {
+	var key [32]byte
+	var nonce [12]byte
+	rand.Read(key[:])
+	rand.Read(nonce[:])
+	plain := []byte("hello")
+	enc, err := crypto.AESSeal(key, nonce, plain)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	out, err := crypto.AESOpen(key, nonce, enc)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if string(out) != string(plain) {
+		t.Fatalf("round-trip mismatch: %q", out)
+	}
+}
+
+func TestRSARoundTrip(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	msg := []byte("secret")
+	enc, err := crypto.RSAEncrypt(&priv.PublicKey, msg)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	out, err := crypto.RSADecrypt(priv, enc)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(out) != string(msg) {
+		t.Fatalf("round-trip mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- move cell logic under domain/value_object
- move cryptographic helpers under infrastructure/crypto
- update tests and imports

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856799192a8832ba75b4c1f691b8af5