### PR TITLE
Handle rand errors

### DIFF
--- a/internal/infrastructure/crypto/crypto_test.go
+++ b/internal/infrastructure/crypto/crypto_test.go
@@ -11,8 +11,12 @@ import (
 func TestAESRoundTrip(t *testing.T) {
 	var key [32]byte
 	var nonce [12]byte
-	rand.Read(key[:])
-	rand.Read(nonce[:])
+	if _, err := rand.Read(key[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
 	plain := []byte("hello")
 	enc, err := crypto.AESSeal(key, nonce, plain)
 	if err != nil {


### PR DESCRIPTION
## Summary
- check `rand.Read` failures in crypto tests
- propagate errors from `secureShuffle`
- bubble shuffle errors in circuit builder

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68567dc46f68832bb401e679f87b87b3