### PR TITLE
Implement relay circuit table as repository

### DIFF
--- a/internal/domain/entity/cell.go
+++ b/internal/domain/entity/cell.go
@@ -1,0 +1,11 @@
+package entity
+
+import "ikedadada/go-ptor/internal/domain/value_object"
+
+// Cell represents a single relay cell exchanged between nodes.
+type Cell struct {
+	CircID   value_object.CircuitID
+	StreamID value_object.StreamID
+	Data     []byte
+	End      bool
+}

--- a/internal/domain/entity/conn_state.go
+++ b/internal/domain/entity/conn_state.go
@@ -1,0 +1,46 @@
+package entity
+
+import (
+	"net"
+	"time"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+// ConnState represents per-circuit connection information held by a relay.
+type ConnState struct {
+	key  value_object.AESKey
+	up   net.Conn
+	down net.Conn
+	last time.Time
+}
+
+// NewConnState returns a new ConnState instance.
+func NewConnState(key value_object.AESKey, up, down net.Conn) *ConnState {
+	return &ConnState{key: key, up: up, down: down, last: time.Now()}
+}
+
+// Key returns the symmetric key for this circuit hop.
+func (s *ConnState) Key() value_object.AESKey { return s.key }
+
+// Up returns the upstream connection.
+func (s *ConnState) Up() net.Conn { return s.up }
+
+// Down returns the downstream connection.
+func (s *ConnState) Down() net.Conn { return s.down }
+
+// Touch updates the last-used time to now.
+func (s *ConnState) Touch() { s.last = time.Now() }
+
+// LastUsed reports the last time the state was accessed.
+func (s *ConnState) LastUsed() time.Time { return s.last }
+
+// Close closes both sides of the connection.
+func (s *ConnState) Close() {
+	if s.up != nil {
+		s.up.Close()
+	}
+	if s.down != nil {
+		s.down.Close()
+	}
+}

--- a/internal/domain/repository/circuit_table_repository.go
+++ b/internal/domain/repository/circuit_table_repository.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+// CircuitTableRepository manages per-hop connection states held by a relay.
+type CircuitTableRepository interface {
+	Add(value_object.CircuitID, *entity.ConnState) error
+	Find(value_object.CircuitID) (*entity.ConnState, error)
+	Delete(value_object.CircuitID) error
+}

--- a/internal/domain/value_object/data_payload.go
+++ b/internal/domain/value_object/data_payload.go
@@ -1,0 +1,26 @@
+package value_object
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+// DataPayload represents application data flowing through a circuit.
+type DataPayload struct {
+	StreamID uint16
+	Data     []byte
+}
+
+// EncodeDataPayload encodes the payload using gob.
+func EncodeDataPayload(p *DataPayload) ([]byte, error) {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(p)
+	return buf.Bytes(), err
+}
+
+// DecodeDataPayload decodes bytes into a DataPayload.
+func DecodeDataPayload(b []byte) (*DataPayload, error) {
+	var p DataPayload
+	err := gob.NewDecoder(bytes.NewReader(b)).Decode(&p)
+	return &p, err
+}

--- a/internal/domain/value_object/data_payload_test.go
+++ b/internal/domain/value_object/data_payload_test.go
@@ -1,0 +1,18 @@
+package value_object
+
+import "testing"
+
+func TestDataPayload_RoundTrip(t *testing.T) {
+	p := &DataPayload{StreamID: 2, Data: []byte("hi")}
+	b, err := EncodeDataPayload(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := DecodeDataPayload(b)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.StreamID != p.StreamID || string(out.Data) != string(p.Data) {
+		t.Errorf("round-trip mismatch")
+	}
+}

--- a/internal/domain/value_object/extend_payload.go
+++ b/internal/domain/value_object/extend_payload.go
@@ -1,0 +1,26 @@
+package value_object
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+// ExtendPayload carries the information needed to extend a circuit to the next hop.
+type ExtendPayload struct {
+	NextHop string
+	EncKey  []byte
+}
+
+// EncodeExtendPayload serializes p using gob.
+func EncodeExtendPayload(p *ExtendPayload) ([]byte, error) {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(p)
+	return buf.Bytes(), err
+}
+
+// DecodeExtendPayload decodes the payload from gob bytes.
+func DecodeExtendPayload(b []byte) (*ExtendPayload, error) {
+	var p ExtendPayload
+	err := gob.NewDecoder(bytes.NewReader(b)).Decode(&p)
+	return &p, err
+}

--- a/internal/domain/value_object/extend_payload_test.go
+++ b/internal/domain/value_object/extend_payload_test.go
@@ -1,0 +1,18 @@
+package value_object
+
+import "testing"
+
+func TestExtendPayload_RoundTrip(t *testing.T) {
+	p := &ExtendPayload{NextHop: "127.0.0.1:5001", EncKey: []byte("secret")}
+	b, err := EncodeExtendPayload(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := DecodeExtendPayload(b)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.NextHop != p.NextHop || string(out.EncKey) != string(p.EncKey) {
+		t.Errorf("mismatch: %+v vs %+v", out, p)
+	}
+}

--- a/internal/infrastructure/repository/circuit_table_repository.go
+++ b/internal/infrastructure/repository/circuit_table_repository.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"sync"
+	"time"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	repoif "ikedadada/go-ptor/internal/domain/repository"
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+type circuitTableRepository struct {
+	mu  sync.RWMutex
+	ttl time.Duration
+	m   map[value_object.CircuitID]*entity.ConnState
+}
+
+// NewCircuitTableRepository creates an in-memory circuit table with automatic cleanup.
+func NewCircuitTableRepository(ttl time.Duration) repoif.CircuitTableRepository {
+	r := &circuitTableRepository{ttl: ttl, m: make(map[value_object.CircuitID]*entity.ConnState)}
+	go r.gc()
+	return r
+}
+
+func (r *circuitTableRepository) Add(id value_object.CircuitID, st *entity.ConnState) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st.Touch()
+	r.m[id] = st
+	return nil
+}
+
+func (r *circuitTableRepository) Find(id value_object.CircuitID) (*entity.ConnState, error) {
+	r.mu.RLock()
+	st, ok := r.m[id]
+	if ok {
+		st.Touch()
+	}
+	r.mu.RUnlock()
+	if !ok {
+		return nil, repoif.ErrNotFound
+	}
+	return st, nil
+}
+
+func (r *circuitTableRepository) Delete(id value_object.CircuitID) error {
+	r.mu.Lock()
+	st, ok := r.m[id]
+	if ok {
+		st.Close()
+		delete(r.m, id)
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *circuitTableRepository) gc() {
+	interval := r.ttl / 2
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	for range ticker.C {
+		r.mu.Lock()
+		for id, st := range r.m {
+			if time.Since(st.LastUsed()) > r.ttl {
+				st.Close()
+				delete(r.m, id)
+			}
+		}
+		r.mu.Unlock()
+	}
+}

--- a/internal/infrastructure/repository/circuit_table_repository_test.go
+++ b/internal/infrastructure/repository/circuit_table_repository_test.go
@@ -1,0 +1,45 @@
+package repository_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	repoif "ikedadada/go-ptor/internal/domain/repository"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	repoimpl "ikedadada/go-ptor/internal/infrastructure/repository"
+)
+
+func TestCircuitTableRepo_AddFindDelete(t *testing.T) {
+	tbl := repoimpl.NewCircuitTableRepository(time.Second)
+	id := value_object.NewCircuitID()
+	st := entity.NewConnState(value_object.AESKey{}, nil, nil)
+	if err := tbl.Add(id, st); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := tbl.Find(id); err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if err := tbl.Delete(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := tbl.Find(id); !errors.Is(err, repoif.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound")
+	}
+}
+
+func TestCircuitTableRepo_GC(t *testing.T) {
+	tbl := repoimpl.NewCircuitTableRepository(500 * time.Millisecond)
+	id := value_object.NewCircuitID()
+	up, down := net.Pipe()
+	st := entity.NewConnState(value_object.AESKey{}, up, down)
+	if err := tbl.Add(id, st); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	time.Sleep(1200 * time.Millisecond)
+	if _, err := tbl.Find(id); !errors.Is(err, repoif.ErrNotFound) {
+		t.Fatalf("entry not cleaned")
+	}
+}

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -1,0 +1,85 @@
+package usecase
+
+import (
+	"crypto/rsa"
+	"errors"
+	"net"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	repoif "ikedadada/go-ptor/internal/domain/repository"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/internal/usecase/service"
+)
+
+// RelayUseCase processes cells for a single relay connection.
+type RelayUseCase interface {
+	Handle(up net.Conn, cell entity.Cell) error
+}
+
+type relayUsecaseImpl struct {
+	priv   *rsa.PrivateKey
+	repo   repoif.CircuitTableRepository
+	crypto service.CryptoService
+}
+
+func NewRelayUseCase(priv *rsa.PrivateKey, repo repoif.CircuitTableRepository, c service.CryptoService) RelayUseCase {
+	return &relayUsecaseImpl{priv: priv, repo: repo, crypto: c}
+}
+
+func (uc *relayUsecaseImpl) Handle(up net.Conn, cell entity.Cell) error {
+	st, err := uc.repo.Find(cell.CircID)
+	switch {
+	case errors.Is(err, repoif.ErrNotFound) && cell.End:
+		// End for an unknown circuit is ignored
+		return nil
+	case errors.Is(err, repoif.ErrNotFound) && cell.StreamID.UInt16() == 0:
+		// new circuit request
+		return uc.extend(up, cell)
+	case err != nil:
+		return err
+	}
+
+	if cell.End {
+		// graceful shutdown of an existing circuit
+		_ = uc.repo.Delete(cell.CircID)
+		return nil
+	}
+
+	if len(cell.Data) < 12 {
+		// ignore malformed payload
+		return nil
+	}
+
+	var nonce [12]byte
+	copy(nonce[:], cell.Data[:12])
+	dec, err := uc.crypto.AESOpen(st.Key(), nonce, cell.Data[12:])
+	if err != nil {
+		return err
+	}
+	_, err = st.Down().Write(dec)
+	return err
+}
+
+func (uc *relayUsecaseImpl) extend(up net.Conn, cell entity.Cell) error {
+	p, err := value_object.DecodeExtendPayload(cell.Data)
+	if err != nil {
+		return err
+	}
+	dec, err := uc.crypto.RSADecrypt(uc.priv, p.EncKey)
+	if err != nil {
+		return err
+	}
+	if len(dec) < 32 {
+		return nil
+	}
+	key, err := value_object.AESKeyFrom(dec[:32])
+	if err != nil {
+		return err
+	}
+	down, err := net.Dial("tcp", p.NextHop)
+	if err != nil {
+		return err
+	}
+	st := entity.NewConnState(key, up, down)
+	return uc.repo.Add(cell.CircID, st)
+}

--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -1,0 +1,56 @@
+package usecase_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net"
+	"testing"
+	"time"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	repoimpl "ikedadada/go-ptor/internal/infrastructure/repository"
+	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
+	"ikedadada/go-ptor/internal/usecase"
+)
+
+func TestRelayUseCase_ExtendAndForward(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	repo := repoimpl.NewCircuitTableRepository(time.Second)
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewRelayUseCase(priv, repo, crypto)
+
+	// prepare extend cell
+	key, _ := value_object.NewAESKey()
+	enc, _ := crypto.RSAEncrypt(&priv.PublicKey, key[:])
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer ln.Close()
+	go func() { ln.Accept() }()
+	payload, _ := value_object.EncodeExtendPayload(&value_object.ExtendPayload{NextHop: ln.Addr().String(), EncKey: enc})
+	cid := value_object.NewCircuitID()
+	cell := entity.Cell{CircID: cid, StreamID: 0, Data: payload}
+
+	up1, _ := net.Pipe()
+	go uc.Handle(up1, cell)
+
+	// ensure entry created
+	time.Sleep(10 * time.Millisecond)
+	st, err := repo.Find(cid)
+	if err != nil {
+		t.Fatalf("entry not created: %v", err)
+	}
+	st.Down().Close()
+	st.Up().Close()
+}
+
+func TestRelayUseCase_EndUnknown(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	repo := repoimpl.NewCircuitTableRepository(time.Second)
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewRelayUseCase(priv, repo, crypto)
+	cid := value_object.NewCircuitID()
+	cell := entity.Cell{CircID: cid, StreamID: 1, End: true}
+	if err := uc.Handle(nil, cell); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- promote ConnState to domain entity
- introduce CircuitTableRepository interface
- implement circuit table repository in infrastructure layer with GC
- update relay main to use new repository
- add tests for repository behavior
- move cell handling logic into RelayUseCase and inject crypto service
- create Cell entity and use it across relay logic
- improve error handling and logging in relay code
- clarify encryption in `readCell`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857506f4e80832b9407c18dec0a95ff