### PR TITLE
Fix relay containers to load private keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "5000:5000"
     volumes:
       - ./docker/relay/relay1.pem:/relay.pem:ro
+    command: ["-priv", "/relay.pem"]
     networks:
       - ptor
 
@@ -19,6 +20,7 @@ services:
       - "5001:5000"
     volumes:
       - ./docker/relay/relay2.pem:/relay.pem:ro
+    command: ["-priv", "/relay.pem"]
     networks:
       - ptor
 
@@ -30,6 +32,7 @@ services:
       - "5002:5000"
     volumes:
       - ./docker/relay/relay3.pem:/relay.pem:ro
+    command: ["-priv", "/relay.pem"]
     networks:
       - ptor
 


### PR DESCRIPTION
## Summary
- instruct relay containers to use the provided `relay.pem` files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857630a2c84832b847a8af530e6590a