### PR TITLE
Implement directory fetch in client

### DIFF
--- a/cmd/directory/main.go
+++ b/cmd/directory/main.go
@@ -6,36 +6,23 @@ import (
 	"log"
 	"net/http"
 	"os"
+
+	"ikedadada/go-ptor/internal/domain/entity"
 )
 
-type Directory struct {
-	Relays         map[string]RelayInfo         `json:"relays"`
-	HiddenServices map[string]HiddenServiceInfo `json:"hidden_services"`
-}
-
-type RelayInfo struct {
-	Endpoint string `json:"endpoint"`
-	PubKey   string `json:"pubkey"`
-}
-
-type HiddenServiceInfo struct {
-	Relay  string `json:"relay"`
-	PubKey string `json:"pubkey"`
-}
-
-func loadDirectory(path string) (Directory, error) {
+func loadDirectory(path string) (entity.Directory, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return Directory{}, err
+		return entity.Directory{}, err
 	}
-	var d Directory
+	var d entity.Directory
 	if err := json.Unmarshal(b, &d); err != nil {
-		return Directory{}, err
+		return entity.Directory{}, err
 	}
 	return d, nil
 }
 
-func handler(d Directory) http.Handler {
+func handler(d entity.Directory) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(d)

--- a/cmd/directory/main_e2e_test.go
+++ b/cmd/directory/main_e2e_test.go
@@ -5,14 +5,16 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"ikedadada/go-ptor/internal/domain/entity"
 )
 
 func TestDirectoryServer(t *testing.T) {
-	data := Directory{
-		Relays: map[string]RelayInfo{
+	data := entity.Directory{
+		Relays: map[string]entity.RelayInfo{
 			"r1": {Endpoint: "127.0.0.1:5000", PubKey: "pk"},
 		},
-		HiddenServices: map[string]HiddenServiceInfo{
+		HiddenServices: map[string]entity.HiddenServiceInfo{
 			"h1": {Relay: "r1", PubKey: "hpk"},
 		},
 	}
@@ -39,7 +41,7 @@ func TestDirectoryServer(t *testing.T) {
 	}
 	defer res.Body.Close()
 
-	var got Directory
+	var got entity.Directory
 	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}

--- a/internal/domain/entity/directory.go
+++ b/internal/domain/entity/directory.go
@@ -1,0 +1,19 @@
+package entity
+
+// Directory represents a response from the directory service.
+type Directory struct {
+	Relays         map[string]RelayInfo         `json:"relays"`
+	HiddenServices map[string]HiddenServiceInfo `json:"hidden_services"`
+}
+
+// RelayInfo contains metadata for a relay node published by the directory.
+type RelayInfo struct {
+	Endpoint string `json:"endpoint"`
+	PubKey   string `json:"pubkey"`
+}
+
+// HiddenServiceInfo maps a hidden service address to its relay and public key.
+type HiddenServiceInfo struct {
+	Relay  string `json:"relay"`
+	PubKey string `json:"pubkey"`
+}


### PR DESCRIPTION
## Summary
- share directory structs across commands
- fetch directory service in client and require -dir flag
- update tests to use the shared types

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685763f987f4832baa0fb1fec6f88b56