### PR TITLE
Fix client container directory config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - relay2
       - relay3
       - directory
+    command: ["-dir", "http://directory:8081"]
     networks:
       - ptor
 


### PR DESCRIPTION
## Summary
- configure the client container to pass a `--dir` flag

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857707fa47c832b81b1452a556699ac