### PR TITLE
Fix docker demo keys parsing and directory IDs

### DIFF
--- a/docker/directory/directory.json
+++ b/docker/directory/directory.json
@@ -1,10 +1,22 @@
 {
   "relays": {
-    "relay1": {"endpoint": "relay1:5000", "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1psRt2O6+3O5Zj/YpiLfh5ndPndPRl2DLhSp1Q2XQfo1jcWpt51AVCgvwLIBAt0ucpxskjlsx4k4T5Im8CU63GFN6fkraTjjZVtXuMIRR7iUjw35N277QZt5Zd7AP9WbWcMn/3j01x2Amn4+V7wuRTSWk/PmS97UegSwvZhucSR4VWqOenvoQFIeeijtD5NODLrqAXJWQ6GkRsPc/aQ91K8vibXc6Xl1RcCWunbo6vWwa4SZUM3nyTX/SiNuft6z5Ac77wk0uiMy0gmWYejkFLIls9hAm0sBGHi3HZ/bsHDYCi7g0IH6rhiKZdDTxngOTzFtqgBWRouqmr1jmYgBQIDAQAB-----END PUBLIC KEY-----"},
-    "relay2": {"endpoint": "relay2:5000", "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwSMeVw/h5qGRFl9rulVXeLA8GAlsC7nvs0ZjPshhqByhYUwYsmlYfcxwvREFCcgivBkj+h9ItaMFqugCF8/lm6Jb6GifbUInHhKgjw2Bp6x5d9qjfjtmrnwRvSbyzPXHzGIsToOKLQ8m0fR+VdlzEdELGoUJJafeAB6jA3xCx576kJ2WnfC1sT81qiIAGiNFHiz7JnmR6X1S/JGsrYqabvATpuJP7JlsaMJs7ePISP5kpQQOIfiaFj6u21GDFAwmtgiRL9T6r4Ru11dHFvn8Yj8sDi91bTZxIkmAR9jik7x+WoMWOSaq3ynwVP4fAf9XZ6be+y4gf5U3mZQst0GJVQIDAQAB-----END PUBLIC KEY-----"},
-    "relay3": {"endpoint": "relay3:5000", "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsThdS0dZk3LZRIo8RPGzzsysYQAy/4BlD4VWIA5WDTp7fDI24qylZxGE8au52lPhTHSwDCgtp7Dg4kwDUKiecXxPKOkXvrJsL6RcJZ+ZrwMElKysO+aS/rRzyBwU1zLJu8+4fjzAYBYJpafa3eDyrs3whmmOAddi9poIJ8GTWprzc8iS9ai43TNfAoNCVEcOgvOxYXgRPCbkFaqTEsJNBzJEwlfoek8vBqQnQFbFZ9grIMyegsgDhU/wRZeMPl9UJ5x+YWqioyMo29hfFn4F9+6UD2a/WEw9HOr8Dn77Aan2Mru60hY8AnkulGay48y6qqfqRRfNi1mn+l3piKV/9wIDAQAB-----END PUBLIC KEY-----"}
+    "42488a8b-e114-439a-ac21-5226313ecdbc": {
+      "endpoint": "relay1:5000",
+      "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1psRt2O6+3O5Zj/YpiLfh5ndPndPRl2DLhSp1Q2XQfo1jcWpt51AVCgvwLIBAt0ucpxskjlsx4k4T5Im8CU63GFN6fkraTjjZVtXuMIRR7iUjw35N277QZt5Zd7AP9WbWcMn/3j01x2Amn4+V7wuRTSWk/PmS97UegSwvZhucSR4VWqOenvoQFIeeijtD5NODLrqAXJWQ6GkRsPc/aQ91K8vibXc6Xl1RcCWunbo6vWwa4SZUM3nyTX/SiNuft6z5Ac77wk0uiMy0gmWYejkFLIls9hAm0sBGHi3HZ/bsHDYCi7g0IH6rhiKZdDTxngOTzFtqgBWRouqmr1jmYgBQIDAQAB-----END PUBLIC KEY-----"
+    },
+    "ff3ddf56-5876-4fa3-8347-336f15323d30": {
+      "endpoint": "relay2:5000",
+      "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwSMeVw/h5qGRFl9rulVXeLA8GAlsC7nvs0ZjPshhqByhYUwYsmlYfcxwvREFCcgivBkj+h9ItaMFqugCF8/lm6Jb6GifbUInHhKgjw2Bp6x5d9qjfjtmrnwRvSbyzPXHzGIsToOKLQ8m0fR+VdlzEdELGoUJJafeAB6jA3xCx576kJ2WnfC1sT81qiIAGiNFHiz7JnmR6X1S/JGsrYqabvATpuJP7JlsaMJs7ePISP5kpQQOIfiaFj6u21GDFAwmtgiRL9T6r4Ru11dHFvn8Yj8sDi91bTZxIkmAR9jik7x+WoMWOSaq3ynwVP4fAf9XZ6be+y4gf5U3mZQst0GJVQIDAQAB-----END PUBLIC KEY-----"
+    },
+    "4b321bcb-5520-494d-a94f-ea041b691d69": {
+      "endpoint": "relay3:5000",
+      "pubkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsThdS0dZk3LZRIo8RPGzzsysYQAy/4BlD4VWIA5WDTp7fDI24qylZxGE8au52lPhTHSwDCgtp7Dg4kwDUKiecXxPKOkXvrJsL6RcJZ+ZrwMElKysO+aS/rRzyBwU1zLJu8+4fjzAYBYJpafa3eDyrs3whmmOAddi9poIJ8GTWprzc8iS9ai43TNfAoNCVEcOgvOxYXgRPCbkFaqTEsJNBzJEwlfoek8vBqQnQFbFZ9grIMyegsgDhU/wRZeMPl9UJ5x+YWqioyMo29hfFn4F9+6UD2a/WEw9HOr8Dn77Aan2Mru60hY8AnkulGay48y6qqfqRRfNi1mn+l3piKV/9wIDAQAB-----END PUBLIC KEY-----"
+    }
   },
   "hidden_services": {
-    "hidden": {"relay": "relay3", "pubkey": "-----BEGIN PUBLIC KEY-----MCowBQYDK2VwAyEAO2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=-----END PUBLIC KEY-----"}
+    "hidden": {
+      "relay": "4b321bcb-5520-494d-a94f-ea041b691d69",
+      "pubkey": "-----BEGIN PUBLIC KEY-----MCowBQYDK2VwAyEAO2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=-----END PUBLIC KEY-----"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- support PKCS#8 private keys in `ptor-relay`
- update the demo directory service to use UUID relay IDs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857736b00e4832bad1f58792f9e8ba4