### PR TITLE
Ensure hidden service binds only to loopback

### DIFF
--- a/cmd/hidden/main.go
+++ b/cmd/hidden/main.go
@@ -10,15 +10,33 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 
 	"ikedadada/go-ptor/internal/domain/value_object"
 )
 
 func main() {
 	keyPath := flag.String("key", "hidden.pem", "ED25519 private key")
-	listen := flag.String("listen", ":5000", "relay listen address")
+	listen := flag.String("listen", "127.0.0.1:5000", "relay listen address (localhost only)")
 	httpAddr := flag.String("http", "127.0.0.1:8080", "HTTP service address")
 	flag.Parse()
+
+	host, _, err := net.SplitHostPort(*listen)
+	if err != nil {
+		log.Fatalf("invalid listen address: %v", err)
+	}
+	if host == "" {
+		host = "0.0.0.0"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		if strings.EqualFold(host, "localhost") {
+			ip = net.ParseIP("127.0.0.1")
+		}
+	}
+	if ip == nil || !ip.IsLoopback() {
+		log.Fatal("hidden service must listen on localhost only")
+	}
 
 	priv, err := loadEDPriv(*keyPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- restrict `ptor-hidden` to listen only on localhost
- validate provided listen address and abort if not loopback

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685789d18ccc832ba707217063dbc6b8