### PR TITLE
Add doc comments for exported use cases

### DIFF
--- a/internal/usecase/build_circuit_usecase.go
+++ b/internal/usecase/build_circuit_usecase.go
@@ -22,8 +22,7 @@ type BuildCircuitOutput struct {
 	AddrList  []value_object.Endpoint `json:"endpoints"`
 }
 
-// ---------- UseCase インターフェース ----------
-
+// BuildCircuitUseCase creates new circuits according to the input parameters.
 type BuildCircuitUseCase interface {
 	Handle(input BuildCircuitInput) (BuildCircuitOutput, error)
 }
@@ -34,7 +33,7 @@ type buildCircuitUseCaseImpl struct {
 	builder service.CircuitBuildService
 }
 
-// コンストラクタ
+// NewBuildCircuitUseCase creates a use case for building circuits.
 func NewBuildCircuitUseCase(b service.CircuitBuildService) BuildCircuitUseCase {
 	return &buildCircuitUseCaseImpl{builder: b}
 }

--- a/internal/usecase/close_stream_usecase.go
+++ b/internal/usecase/close_stream_usecase.go
@@ -8,15 +8,18 @@ import (
 	"ikedadada/go-ptor/internal/usecase/service"
 )
 
+// CloseStreamInput identifies the stream to close on a circuit.
 type CloseStreamInput struct {
 	CircuitID string
 	StreamID  uint16
 }
 
+// CloseStreamOutput indicates whether the close operation succeeded.
 type CloseStreamOutput struct {
 	Closed bool `json:"closed"`
 }
 
+// CloseStreamUseCase terminates an existing stream.
 type CloseStreamUseCase interface {
 	Handle(in CloseStreamInput) (CloseStreamOutput, error)
 }
@@ -26,6 +29,7 @@ type closeStreamUsecaseImpl struct {
 	tx service.CircuitTransmitter
 }
 
+// NewCloseStreamUsecase creates a use case for closing streams.
 func NewCloseStreamUsecase(cr repository.CircuitRepository, tx service.CircuitTransmitter) CloseStreamUseCase {
 	return &closeStreamUsecaseImpl{cr: cr, tx: tx}
 }

--- a/internal/usecase/destroy_circuit_usecase.go
+++ b/internal/usecase/destroy_circuit_usecase.go
@@ -13,10 +13,12 @@ type DestroyCircuitInput struct {
 	CircuitID string
 }
 
+// DestroyCircuitOutput is returned after a circuit is aborted.
 type DestroyCircuitOutput struct {
 	Aborted bool `json:"aborted"`
 }
 
+// DestroyCircuitUseCase aborts an existing circuit.
 type DestroyCircuitUseCase interface {
 	Handle(in DestroyCircuitInput) (DestroyCircuitOutput, error)
 }
@@ -26,6 +28,7 @@ type destroyCircuitUsecaseImpl struct {
 	tx   service.CircuitTransmitter
 }
 
+// NewDestroyCircuitUsecase returns a use case to abort circuits.
 func NewDestroyCircuitUsecase(r repository.CircuitRepository, tx service.CircuitTransmitter) DestroyCircuitUseCase {
 	return &destroyCircuitUsecaseImpl{repo: r, tx: tx}
 }

--- a/internal/usecase/handle_end_usecase.go
+++ b/internal/usecase/handle_end_usecase.go
@@ -13,10 +13,12 @@ type HandleEndInput struct {
 	StreamID  uint16 // 0 means control END
 }
 
+// HandleEndOutput reports the result of closing streams.
 type HandleEndOutput struct {
 	Closed bool `json:"closed"`
 }
 
+// HandleEndUseCase processes incoming END cells.
 type HandleEndUseCase interface {
 	Handle(in HandleEndInput) (HandleEndOutput, error)
 }
@@ -25,6 +27,7 @@ type handleEndUsecaseImpl struct {
 	repo repository.CircuitRepository
 }
 
+// NewHandleEndUsecase creates a use case for handling END cells.
 func NewHandleEndUsecase(r repository.CircuitRepository) HandleEndUseCase {
 	return &handleEndUsecaseImpl{repo: r}
 }

--- a/internal/usecase/open_stream_usecase.go
+++ b/internal/usecase/open_stream_usecase.go
@@ -7,15 +7,18 @@ import (
 	"ikedadada/go-ptor/internal/domain/value_object"
 )
 
+// OpenStreamInput specifies which circuit to open a new stream for.
 type OpenStreamInput struct {
 	CircuitID string
 }
 
+// OpenStreamOutput holds the created stream identifier.
 type OpenStreamOutput struct {
 	CircuitID string `json:"circuit_id"`
 	StreamID  uint16 `json:"stream_id"`
 }
 
+// OpenStreamUseCase opens a new stream on an existing circuit.
 type OpenStreamUseCase interface {
 	Handle(in OpenStreamInput) (OpenStreamOutput, error)
 }
@@ -25,6 +28,7 @@ type openStreamUseCaseImpl struct {
 	cr repository.CircuitRepository
 }
 
+// NewOpenStreamUsecase returns a use case to open streams on circuits.
 func NewOpenStreamUsecase(cr repository.CircuitRepository) *openStreamUseCaseImpl {
 	return &openStreamUseCaseImpl{cr: cr}
 }

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -22,6 +22,7 @@ type relayUsecaseImpl struct {
 	crypto service.CryptoService
 }
 
+// NewRelayUseCase returns a use case to process relay connections.
 func NewRelayUseCase(priv *rsa.PrivateKey, repo repoif.CircuitTableRepository, c service.CryptoService) RelayUseCase {
 	return &relayUsecaseImpl{priv: priv, repo: repo, crypto: c}
 }

--- a/internal/usecase/send_data_usecase.go
+++ b/internal/usecase/send_data_usecase.go
@@ -7,16 +7,19 @@ import (
 	"ikedadada/go-ptor/internal/usecase/service"
 )
 
+// SendDataInput represents application data to forward on a circuit.
 type SendDataInput struct {
 	CircuitID string
 	StreamID  uint16
 	Data      []byte
 }
 
+// SendDataOutput reports how many bytes were sent.
 type SendDataOutput struct {
 	BytesSent int `json:"bytes_sent"`
 }
 
+// SendDataUseCase forwards data through a circuit.
 type SendDataUseCase interface {
 	Handle(in SendDataInput) (SendDataOutput, error)
 }
@@ -26,6 +29,7 @@ type sendDataUseCaseImpl struct {
 	tx service.CircuitTransmitter
 }
 
+// NewSendDataUsecase returns a use case for sending data cells.
 func NewSendDataUsecase(cr repository.CircuitRepository, tx service.CircuitTransmitter) SendDataUseCase {
 	return &sendDataUseCaseImpl{cr: cr, tx: tx}
 }

--- a/internal/usecase/shutdown_circuit_usecase.go
+++ b/internal/usecase/shutdown_circuit_usecase.go
@@ -8,14 +8,17 @@ import (
 	"ikedadada/go-ptor/internal/usecase/service"
 )
 
+// ShutdownCircuitInput specifies which circuit to close gracefully.
 type ShutdownCircuitInput struct {
 	CircuitID string
 }
 
+// ShutdownCircuitOutput reports whether shutdown succeeded.
 type ShutdownCircuitOutput struct {
 	Success bool `json:"success"`
 }
 
+// ShutdownCircuitUseCase closes all streams and removes the circuit.
 type ShutdownCircuitUseCase interface {
 	Handle(in ShutdownCircuitInput) (ShutdownCircuitOutput, error)
 }
@@ -25,6 +28,7 @@ type shutdownCircuitUseCaseImpl struct {
 	tx   service.CircuitTransmitter
 }
 
+// NewShutdownCircuitUsecase returns a use case for orderly circuit shutdown.
 func NewShutdownCircuitUsecase(cr repository.CircuitRepository, tx service.CircuitTransmitter) ShutdownCircuitUseCase {
 	return &shutdownCircuitUseCaseImpl{repo: cr, tx: tx}
 }


### PR DESCRIPTION
## Summary
- document exported structs and constructors in `internal/usecase`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685789d54428832ba80b2c029d0e3c6f