### PR TITLE
Implement layered AES encryption

### DIFF
--- a/internal/infrastructure/service/crypto_service_test.go
+++ b/internal/infrastructure/service/crypto_service_test.go
@@ -32,6 +32,29 @@ func TestAESRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAESMultiRoundTrip(t *testing.T) {
+	var k1, k2 [32]byte
+	var n1, n2 [12]byte
+	rand.Read(k1[:])
+	rand.Read(k2[:])
+	rand.Read(n1[:])
+	rand.Read(n2[:])
+
+	plain := []byte("hello")
+	svc := service.NewCryptoService()
+	enc, err := svc.AESMultiSeal([][32]byte{k1, k2}, [][12]byte{n1, n2}, plain)
+	if err != nil {
+		t.Fatalf("seal multi: %v", err)
+	}
+	out, err := svc.AESMultiOpen([][32]byte{k1, k2}, [][12]byte{n1, n2}, enc)
+	if err != nil {
+		t.Fatalf("open multi: %v", err)
+	}
+	if string(out) != string(plain) {
+		t.Fatalf("round-trip mismatch: %q", out)
+	}
+}
+
 func TestRSARoundTrip(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/internal/usecase/service/crypto_service.go
+++ b/internal/usecase/service/crypto_service.go
@@ -8,4 +8,10 @@ type CryptoService interface {
 	RSADecrypt(priv *rsa.PrivateKey, in []byte) ([]byte, error)
 	AESSeal(key [32]byte, nonce [12]byte, plain []byte) ([]byte, error)
 	AESOpen(key [32]byte, nonce [12]byte, enc []byte) ([]byte, error)
+	// AESMultiSeal applies AESSeal repeatedly with the given keys and nonces
+	// from last to first, producing an onion-encrypted payload.
+	AESMultiSeal(keys [][32]byte, nonces [][12]byte, plain []byte) ([]byte, error)
+	// AESMultiOpen decrypts an onion-encrypted payload by sequentially
+	// applying AESOpen with each key and nonce in order.
+	AESMultiOpen(keys [][32]byte, nonces [][12]byte, enc []byte) ([]byte, error)
 }


### PR DESCRIPTION
## Summary
- extend CryptoService interface with AESMultiSeal and AESMultiOpen
- implement layered encryption/decryption in crypto service
- add tests for multi-layer AES encryption

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685789c3ed60832ba334653f02757b56