### PR TITLE
Add ephemeral RSA keys for circuits

### DIFF
--- a/internal/domain/entity/circuit_test.go
+++ b/internal/domain/entity/circuit_test.go
@@ -1,9 +1,12 @@
 package entity_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
 	"ikedadada/go-ptor/internal/domain/entity"
 	"ikedadada/go-ptor/internal/domain/value_object"
-	"testing"
 )
 
 func TestNewCircuit_Table(t *testing.T) {
@@ -23,6 +26,7 @@ func TestNewCircuit_Table(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NonceFrom: %v", err)
 	}
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
 	tests := []struct {
 		name       string
 		relays     []value_object.RelayID
@@ -36,7 +40,7 @@ func TestNewCircuit_Table(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := entity.NewCircuit(id, tt.relays, tt.keys, tt.nonces)
+			c, err := entity.NewCircuit(id, tt.relays, tt.keys, tt.nonces, priv)
 			if tt.expectsErr && err == nil {
 				t.Errorf("expected error")
 			}
@@ -74,7 +78,8 @@ func TestCircuit_StreamManagement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := entity.NewCircuit(id, []value_object.RelayID{relayID, relayID, relayID}, []value_object.AESKey{key, key, key}, []value_object.Nonce{nonce, nonce, nonce})
+			priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+			c, err := entity.NewCircuit(id, []value_object.RelayID{relayID, relayID, relayID}, []value_object.AESKey{key, key, key}, []value_object.Nonce{nonce, nonce, nonce}, priv)
 			if err != nil {
 				t.Fatalf("NewCircuit: %v", err)
 			}

--- a/internal/infrastructure/repository/circuit_repository.go
+++ b/internal/infrastructure/repository/circuit_repository.go
@@ -35,7 +35,10 @@ func (r *circuitRepository) Find(id value_object.CircuitID) (*entity.Circuit, er
 func (r *circuitRepository) Delete(id value_object.CircuitID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.m, id)
+	if c, ok := r.m[id]; ok {
+		c.WipeKeys()
+		delete(r.m, id)
+	}
 	return nil
 }
 func (r *circuitRepository) ListActive() ([]*entity.Circuit, error) {

--- a/internal/infrastructure/repository/circuit_repository_test.go
+++ b/internal/infrastructure/repository/circuit_repository_test.go
@@ -1,6 +1,8 @@
 package repository_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -23,7 +25,11 @@ func makeTestCircuit(id value_object.CircuitID) (*entity.Circuit, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 	if err != nil {
 		return nil, err
 	}
@@ -57,6 +63,9 @@ func TestCircuitRepo_Save_Find_Delete(t *testing.T) {
 			}
 			if _, err = repo.Find(id); !errors.Is(err, repoif.ErrNotFound) {
 				t.Errorf("expected ErrNotFound after delete, got %v", err)
+			}
+			if c.RSAPrivate() != nil {
+				t.Errorf("rsa key not wiped")
 			}
 		})
 	}

--- a/internal/usecase/destroy_circuit_usecase_test.go
+++ b/internal/usecase/destroy_circuit_usecase_test.go
@@ -48,7 +48,7 @@ func makeCircuitForDestroy() (*entity.Circuit, error) {
 	key, _ := value_object.NewAESKey()
 	nonce, _ := value_object.NewNonce()
 	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
-	c, err := entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	c, err := entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/destroy_circuit_usecase_test.go
+++ b/internal/usecase/destroy_circuit_usecase_test.go
@@ -1,6 +1,8 @@
 package usecase_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -41,7 +43,8 @@ func makeCircuitForDestroy() (*entity.Circuit, error) {
 	rid, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
 	key, _ := value_object.NewAESKey()
 	nonce, _ := value_object.NewNonce()
-	return entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	return entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 }
 
 func TestDestroyCircuitUsecase(t *testing.T) {

--- a/internal/usecase/handle_end_usecase_test.go
+++ b/internal/usecase/handle_end_usecase_test.go
@@ -1,6 +1,8 @@
 package usecase_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 
 	"ikedadada/go-ptor/internal/domain/entity"
@@ -27,7 +29,8 @@ func makeCircuitForEnd() (*entity.Circuit, value_object.StreamID, error) {
 	rid, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
 	key, _ := value_object.NewAESKey()
 	nonce, _ := value_object.NewNonce()
-	cir, err := entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	cir, err := entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/usecase/open_stream_usecase_test.go
+++ b/internal/usecase/open_stream_usecase_test.go
@@ -1,6 +1,8 @@
 package usecase_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -39,7 +41,11 @@ func makeTestCircuit() (*entity.Circuit, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/service/circuit_build_service.go
+++ b/internal/usecase/service/circuit_build_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/rsa"
 	"encoding/binary"
 	"fmt"
 
@@ -69,11 +70,16 @@ func (b *circuitBuildServiceImpl) Build(hops int) (*entity.Circuit, error) {
 		nonces = append(nonces, n)
 	}
 
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate rsa key: %w", err)
+	}
+
 	// 3. CircuitID 生成
 	cid := value_object.NewCircuitID()
 
 	// 4. Circuit エンティティ生成
-	circuit, err := entity.NewCircuit(cid, relayIDs, keys, nonces)
+	circuit, err := entity.NewCircuit(cid, relayIDs, keys, nonces, priv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/service/circuit_build_service_test.go
+++ b/internal/usecase/service/circuit_build_service_test.go
@@ -98,6 +98,9 @@ func TestCircuitBuildService_Build_Table(t *testing.T) {
 			if !tt.expectsErr && circuit == nil {
 				t.Errorf("expected circuit instance")
 			}
+			if !tt.expectsErr && circuit.RSAPrivate() == nil {
+				t.Errorf("expected rsa key")
+			}
 		})
 	}
 }

--- a/internal/usecase/shutdown_circuit_usecase_test.go
+++ b/internal/usecase/shutdown_circuit_usecase_test.go
@@ -1,6 +1,8 @@
 package usecase_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -62,7 +64,11 @@ func makeTestCircuitShutdown() (*entity.Circuit, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce})
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	c, err := entity.NewCircuit(id, []value_object.RelayID{relayID}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- generate a fresh RSA key pair when building a circuit
- store the key in the circuit entity and wipe keys on delete
- ensure tests use the new constructor
- verify key removal in repository tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685789d371e8832b997696727b29fc75