### PR TITLE
Expose directory sub-endpoints

### DIFF
--- a/cmd/directory/main.go
+++ b/cmd/directory/main.go
@@ -22,11 +22,17 @@ func loadDirectory(path string) (entity.Directory, error) {
 	return d, nil
 }
 
-func handler(d entity.Directory) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func newMux(d entity.Directory) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/relays.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(d)
+		json.NewEncoder(w).Encode(entity.Directory{Relays: d.Relays})
 	})
+	mux.HandleFunc("/hidden.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entity.Directory{HiddenServices: d.HiddenServices})
+	})
+	return mux
 }
 
 func main() {
@@ -40,5 +46,5 @@ func main() {
 	}
 
 	log.Println("directory server listening on", *listen)
-	log.Fatal(http.ListenAndServe(*listen, handler(dir)))
+	log.Fatal(http.ListenAndServe(*listen, newMux(dir)))
 }

--- a/cmd/directory/main_e2e_test.go
+++ b/cmd/directory/main_e2e_test.go
@@ -32,12 +32,12 @@ func TestDirectoryServer(t *testing.T) {
 		t.Fatalf("loadDirectory: %v", err)
 	}
 
-	srv := httptest.NewServer(handler(dir))
+	srv := httptest.NewServer(newMux(dir))
 	defer srv.Close()
 
-	res, err := srv.Client().Get(srv.URL)
+	res, err := srv.Client().Get(srv.URL + "/relays.json")
 	if err != nil {
-		t.Fatalf("http get: %v", err)
+		t.Fatalf("http get relays: %v", err)
 	}
 	defer res.Body.Close()
 
@@ -48,7 +48,18 @@ func TestDirectoryServer(t *testing.T) {
 	if got.Relays["r1"].Endpoint != "127.0.0.1:5000" {
 		t.Errorf("relay endpoint mismatch")
 	}
-	if got.HiddenServices["h1"].Relay != "r1" {
+
+	res2, err := srv.Client().Get(srv.URL + "/hidden.json")
+	if err != nil {
+		t.Fatalf("http get hidden: %v", err)
+	}
+	defer res2.Body.Close()
+
+	var got2 entity.Directory
+	if err := json.NewDecoder(res2.Body).Decode(&got2); err != nil {
+		t.Fatalf("decode hidden: %v", err)
+	}
+	if got2.HiddenServices["h1"].Relay != "r1" {
 		t.Errorf("hidden relay mismatch")
 	}
 }


### PR DESCRIPTION
## Summary
- update directory server to serve `/relays.json` and `/hidden.json`
- add ServeMux for directory server
- update e2e tests to verify both endpoints

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68579ba75574832ba190955efca711ac