### PR TITLE
Fetch relays/hidden separately

### DIFF
--- a/cmd/client/main_e2e_test.go
+++ b/cmd/client/main_e2e_test.go
@@ -76,10 +76,16 @@ func TestClientMain_E2E(t *testing.T) {
 			uuid.NewString(): {Endpoint: "127.0.0.1:5000", PubKey: pem},
 		},
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/relays.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(dirData)
-	}))
+		json.NewEncoder(w).Encode(entity.Directory{Relays: dirData.Relays})
+	})
+	mux.HandleFunc("/hidden.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entity.Directory{HiddenServices: map[string]entity.HiddenServiceInfo{}})
+	})
+	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	exe := buildBin(t)


### PR DESCRIPTION
## Summary
- fetch relays and hidden service lists from `/relays.json` and `/hidden.json`
- expect a base directory URL via the `-dir` flag
- update client e2e test for new directory endpoints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68579d346590832b9f18b670fdc4ceaf