### PR TITLE
Implement EXTEND handshake during circuit build

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -135,7 +135,9 @@ func main() {
 		}
 	}
 
-	builder := useSvc.NewCircuitBuildService(relayRepository, circuitRepository)
+	dialer := infraSvc.NewMemDialer()
+	cryptoSvc := infraSvc.NewCryptoService()
+	builder := useSvc.NewCircuitBuildService(relayRepository, circuitRepository, dialer, cryptoSvc)
 	buildUC := usecase.NewBuildCircuitUseCase(builder)
 
 	out, err := buildUC.Handle(usecase.BuildCircuitInput{Hops: *hops})

--- a/internal/infrastructure/service/mem_dialer.go
+++ b/internal/infrastructure/service/mem_dialer.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"net"
+	"time"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	useSvc "ikedadada/go-ptor/internal/usecase/service"
+)
+
+// MemDialer is a no-op dialer for tests and demos.
+type MemDialer struct{}
+
+// NewMemDialer returns a CircuitDialer that performs no network I/O.
+func NewMemDialer() useSvc.CircuitDialer { return &MemDialer{} }
+
+func (MemDialer) Dial(string) (net.Conn, error)                      { return dummyConn{}, nil }
+func (MemDialer) SendCell(net.Conn, entity.Cell) error               { return nil }
+func (MemDialer) WaitAck(net.Conn) error                             { return nil }
+func (MemDialer) SendDestroy(net.Conn, value_object.CircuitID) error { return nil }
+
+// dummyConn implements net.Conn but does nothing.
+type dummyConn struct{}
+
+func (dummyConn) Read([]byte) (int, error)         { return 0, nil }
+func (dummyConn) Write([]byte) (int, error)        { return 0, nil }
+func (dummyConn) Close() error                     { return nil }
+func (dummyConn) LocalAddr() net.Addr              { return nil }
+func (dummyConn) RemoteAddr() net.Addr             { return nil }
+func (dummyConn) SetDeadline(t time.Time) error    { return nil }
+func (dummyConn) SetReadDeadline(time.Time) error  { return nil }
+func (dummyConn) SetWriteDeadline(time.Time) error { return nil }

--- a/internal/infrastructure/service/tcp_dialer.go
+++ b/internal/infrastructure/service/tcp_dialer.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	useSvc "ikedadada/go-ptor/internal/usecase/service"
+)
+
+// TCPDialer implements service.CircuitDialer over raw TCP connections.
+type TCPDialer struct{}
+
+// NewTCPDialer returns a CircuitDialer using TCP.
+func NewTCPDialer() useSvc.CircuitDialer { return &TCPDialer{} }
+
+func (TCPDialer) Dial(addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
+
+func (TCPDialer) SendCell(conn net.Conn, c entity.Cell) error {
+	var hdr [20]byte
+	copy(hdr[:16], c.CircID.Bytes())
+	binary.BigEndian.PutUint16(hdr[16:18], c.StreamID.UInt16())
+	if c.End {
+		binary.BigEndian.PutUint16(hdr[18:20], 0xFFFF)
+		_, err := conn.Write(hdr[:])
+		return err
+	}
+	binary.BigEndian.PutUint16(hdr[18:20], uint16(len(c.Data)))
+	if _, err := conn.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := conn.Write(c.Data)
+	return err
+}
+
+func (TCPDialer) WaitAck(conn net.Conn) error {
+	var buf [20]byte
+	_, err := io.ReadFull(conn, buf[:])
+	return err
+}
+
+func (TCPDialer) SendDestroy(conn net.Conn, cid value_object.CircuitID) error {
+	var buf [20]byte
+	copy(buf[:16], cid.Bytes())
+	buf[18] = 0xFE
+	_, err := conn.Write(buf[:])
+	return err
+}

--- a/internal/usecase/service/circuit_build_service.go
+++ b/internal/usecase/service/circuit_build_service.go
@@ -21,13 +21,14 @@ type CircuitBuildService interface {
 
 // CircuitBuilder はリレー選択・鍵生成・Circuit 保存をまとめたドメインサービス。
 type circuitBuildServiceImpl struct {
-	rr repository.RelayRepository
-	cr repository.CircuitRepository
+	rr     repository.RelayRepository
+	cr     repository.CircuitRepository
+	dialer CircuitDialer
+	crypto CryptoService
 }
 
-func NewCircuitBuildService(rr repository.RelayRepository, cr repository.CircuitRepository) CircuitBuildService {
-
-	return &circuitBuildServiceImpl{rr: rr, cr: cr}
+func NewCircuitBuildService(rr repository.RelayRepository, cr repository.CircuitRepository, d CircuitDialer, c CryptoService) CircuitBuildService {
+	return &circuitBuildServiceImpl{rr: rr, cr: cr, dialer: d, crypto: c}
 }
 
 // Build は新しい Circuit を生成してリポジトリに保存し、返す。
@@ -84,8 +85,53 @@ func (b *circuitBuildServiceImpl) Build(hops int) (*entity.Circuit, error) {
 		return nil, err
 	}
 
+	// --- build circuit over the network ---
+	conn, err := b.dialer.Dial(selected[0].Endpoint().String())
+	if err != nil {
+		return nil, err
+	}
+	circuit.SetConn(0, conn)
+
+	for i := 0; i < hops; i++ {
+		next := ""
+		if i+1 < hops {
+			next = selected[i+1].Endpoint().String()
+		}
+		var msg []byte
+		msg = append(msg, keys[i][:]...)
+		msg = append(msg, nonces[i][:]...)
+		enc, err := b.crypto.RSAEncrypt(selected[i].PubKey().PublicKey, msg)
+		if err != nil {
+			_ = b.dialer.SendDestroy(conn, cid)
+			conn.Close()
+			return nil, err
+		}
+		payload, err := value_object.EncodeExtendPayload(&value_object.ExtendPayload{
+			NextHop: next,
+			EncKey:  enc,
+		})
+		if err != nil {
+			_ = b.dialer.SendDestroy(conn, cid)
+			conn.Close()
+			return nil, err
+		}
+		cell := entity.Cell{CircID: cid, StreamID: 0, Data: payload}
+		if err := b.dialer.SendCell(conn, cell); err != nil {
+			_ = b.dialer.SendDestroy(conn, cid)
+			conn.Close()
+			return nil, err
+		}
+		if err := b.dialer.WaitAck(conn); err != nil {
+			_ = b.dialer.SendDestroy(conn, cid)
+			conn.Close()
+			return nil, err
+		}
+	}
+
 	// 5. 保存
 	if err := b.cr.Save(circuit); err != nil {
+		_ = b.dialer.SendDestroy(conn, cid)
+		conn.Close()
 		return nil, fmt.Errorf("save circuit: %w", err)
 	}
 

--- a/internal/usecase/service/circuit_dialer.go
+++ b/internal/usecase/service/circuit_dialer.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"net"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+// CircuitDialer abstracts the network operations needed during circuit build.
+type CircuitDialer interface {
+	// Dial connects to the given relay address.
+	Dial(addr string) (net.Conn, error)
+	// SendCell writes a cell to the relay.
+	SendCell(conn net.Conn, cell entity.Cell) error
+	// WaitAck blocks until an ACK for the given circuit is received.
+	WaitAck(conn net.Conn) error
+	// SendDestroy notifies the relay about circuit teardown.
+	SendDestroy(conn net.Conn, cid value_object.CircuitID) error
+}


### PR DESCRIPTION
## Summary
- add CircuitDialer interface for handshake
- extend CircuitBuildService to dial relays and exchange EXTEND cells
- add TCPDialer and MemDialer implementations
- store connection in Circuit entity
- update client and tests for new dialer

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68579f18dd58832bb27dcdb5ae974de5