### PR TITLE
Unify cell encoding

### DIFF
--- a/cmd/relay/main_e2e_test.go
+++ b/cmd/relay/main_e2e_test.go
@@ -1,17 +1,17 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/binary"
-	"net"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
+        "bytes"
+        "context"
+        "net"
+        "os/exec"
+        "path/filepath"
+        "strings"
+        "testing"
+        "time"
 
-	"github.com/google/uuid"
+        "github.com/google/uuid"
+        "ikedadada/go-ptor/internal/domain/value_object"
 )
 
 func freePort(t *testing.T) string {
@@ -65,16 +65,14 @@ func TestRelayMain_E2E(t *testing.T) {
 		t.Fatalf("dial relay: %v", err)
 	}
 
-	cid := uuid.New()
-	sid := uint16(1)
-	data := []byte("ok")
-	buf := new(bytes.Buffer)
-	buf.Write(cid[:])
-	binary.Write(buf, binary.BigEndian, sid)
-	binary.Write(buf, binary.BigEndian, uint16(len(data)))
-	buf.Write(data)
-	c.Write(buf.Bytes())
-	c.Close()
+        cid := uuid.New()
+        sid := uint16(1)
+        data := []byte("ok")
+        inner, _ := value_object.EncodeDataPayload(&value_object.DataPayload{StreamID: sid, Data: data})
+        cellBuf, _ := value_object.Encode(value_object.Cell{Cmd: value_object.CmdData, Version: value_object.Version, Payload: inner})
+        outBuf := append(cid[:], cellBuf...)
+        c.Write(outBuf)
+        c.Close()
 
 	time.Sleep(100 * time.Millisecond)
 	cancel()

--- a/internal/infrastructure/service/tcp_transmitter.go
+++ b/internal/infrastructure/service/tcp_transmitter.go
@@ -1,17 +1,13 @@
 package service
 
 import (
-	"encoding/binary"
-	"fmt"
-	"net"
-	"sync"
+        "fmt"
+        "net"
+        "sync"
 
-	"ikedadada/go-ptor/internal/domain/value_object"
-	"ikedadada/go-ptor/internal/usecase/service" // 依存関係のために必要
+        "ikedadada/go-ptor/internal/domain/value_object"
+        "ikedadada/go-ptor/internal/usecase/service" // 依存関係のために必要
 )
-
-// 簡易セル: | CID(16B) | SID(2B) | LEN(2B) | DATA |
-const hdr = 20 // 16+2+2
 
 type TCPTransmitter struct {
 	mu   sync.Mutex
@@ -26,33 +22,38 @@ func NewTCPTransmitter(addr string) (service.CircuitTransmitter, error) {
 	return &TCPTransmitter{conn: c}, nil
 }
 
-func (t *TCPTransmitter) send(cid value_object.CircuitID, sid value_object.StreamID, data []byte, flag byte) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+func (t *TCPTransmitter) send(cmd byte, payload []byte) error {
+        t.mu.Lock()
+        defer t.mu.Unlock()
 
-	buf := make([]byte, hdr+len(data))
-	copy(buf[:16], cid.Bytes())
-	binary.BigEndian.PutUint16(buf[16:18], sid.UInt16())
-	binary.BigEndian.PutUint16(buf[18:20], uint16(len(data)))
-	copy(buf[20:], data)
-	if flag != 0 {
-		buf[18] = flag // 特殊フラグ
-	}
-	_, err := t.conn.Write(buf)
-	return err
+        cell := value_object.Cell{Cmd: cmd, Version: value_object.Version, Payload: payload}
+        buf, err := value_object.Encode(cell)
+        if err != nil {
+                return err
+        }
+        _, err = t.conn.Write(buf)
+        return err
 }
 
-func (t *TCPTransmitter) SendData(c value_object.CircuitID, s value_object.StreamID, d []byte) error {
-	if len(d) > 65535 {
-		return fmt.Errorf("data too big")
-	}
-	return t.send(c, s, d, 0)
+func (t *TCPTransmitter) SendData(_ value_object.CircuitID, s value_object.StreamID, d []byte) error {
+        if len(d) > value_object.MaxPayloadSize {
+                return fmt.Errorf("data too big")
+        }
+        p, err := value_object.EncodeDataPayload(&value_object.DataPayload{StreamID: s.UInt16(), Data: d})
+        if err != nil {
+                return err
+        }
+        return t.send(value_object.CmdData, p)
 }
 
-func (t *TCPTransmitter) SendEnd(c value_object.CircuitID, s value_object.StreamID) error {
-	return t.send(c, s, nil, 0xFF)
+func (t *TCPTransmitter) SendEnd(_ value_object.CircuitID, s value_object.StreamID) error {
+        p, err := value_object.EncodeDataPayload(&value_object.DataPayload{StreamID: s.UInt16()})
+        if err != nil {
+                return err
+        }
+        return t.send(value_object.CmdEnd, p)
 }
 
-func (t *TCPTransmitter) SendDestroy(c value_object.CircuitID) error {
-	return t.send(c, 0, nil, 0xFE)
+func (t *TCPTransmitter) SendDestroy(value_object.CircuitID) error {
+        return t.send(value_object.CmdDestroy, nil)
 }

--- a/internal/infrastructure/service/tcp_transmitter_test.go
+++ b/internal/infrastructure/service/tcp_transmitter_test.go
@@ -1,10 +1,9 @@
 package service_test
 
 import (
-	"bytes"
-	"net"
-	"testing"
-	"time"
+        "net"
+        "testing"
+        "time"
 
 	"ikedadada/go-ptor/internal/domain/value_object"
 	"ikedadada/go-ptor/internal/infrastructure/service"
@@ -54,44 +53,66 @@ func TestTCPTransmitter_SendData_SendEnd_realConn(t *testing.T) {
 	sid := value_object.NewStreamIDAuto()
 	data := []byte("hello")
 
-	err = tx.SendData(cid, sid, data)
-	if err != nil {
-		t.Fatalf("SendData error: %v", err)
-	}
-	select {
-	case msg := <-received:
-		if !bytes.Contains(msg, data) {
-			t.Errorf("data not found in sent buffer")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for SendData")
-	}
+        err = tx.SendData(cid, sid, data)
+        if err != nil {
+                t.Fatalf("SendData error: %v", err)
+        }
+        select {
+        case msg := <-received:
+                if len(msg) != value_object.MaxCellSize {
+                        t.Fatalf("unexpected cell size %d", len(msg))
+                }
+                cell, err := value_object.Decode(msg)
+                if err != nil {
+                        t.Fatalf("decode: %v", err)
+                }
+                if cell.Cmd != value_object.CmdData {
+                        t.Errorf("unexpected cmd %d", cell.Cmd)
+                }
+                p, err := value_object.DecodeDataPayload(cell.Payload)
+                if err != nil {
+                        t.Fatalf("payload: %v", err)
+                }
+                if string(p.Data) != string(data) || p.StreamID != sid.UInt16() {
+                        t.Errorf("payload mismatch")
+                }
+        case <-time.After(time.Second):
+                t.Fatal("timeout waiting for SendData")
+        }
 
-	err = tx.SendEnd(cid, sid)
-	if err != nil {
-		t.Fatalf("SendEnd error: %v", err)
-	}
-	select {
-	case msg := <-received:
-		if len(msg) < 20 || msg[18] != 0xFF {
-			t.Errorf("END cell not detected in sent buffer")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for SendEnd")
-	}
+        err = tx.SendEnd(cid, sid)
+        if err != nil {
+                t.Fatalf("SendEnd error: %v", err)
+        }
+        select {
+        case msg := <-received:
+                cell, err := value_object.Decode(msg)
+                if err != nil {
+                        t.Fatalf("decode: %v", err)
+                }
+                if cell.Cmd != value_object.CmdEnd {
+                        t.Errorf("expected END cmd, got %d", cell.Cmd)
+                }
+        case <-time.After(time.Second):
+                t.Fatal("timeout waiting for SendEnd")
+        }
 
-	err = tx.SendDestroy(cid)
-	if err != nil {
-		t.Fatalf("SendDestroy error: %v", err)
-	}
-	select {
-	case msg := <-received:
-		if len(msg) < 20 || msg[18] != 0xFE {
-			t.Errorf("DESTROY cell not detected in sent buffer")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for SendDestroy")
-	}
+        err = tx.SendDestroy(cid)
+        if err != nil {
+                t.Fatalf("SendDestroy error: %v", err)
+        }
+        select {
+        case msg := <-received:
+                cell, err := value_object.Decode(msg)
+                if err != nil {
+                        t.Fatalf("decode: %v", err)
+                }
+                if cell.Cmd != value_object.CmdDestroy {
+                        t.Errorf("expected DESTROY cmd, got %d", cell.Cmd)
+                }
+        case <-time.After(time.Second):
+                t.Fatal("timeout waiting for SendDestroy")
+        }
 }
 
 func TestTCPTransmitter_SendData_tooBig_realConn(t *testing.T) {
@@ -103,7 +124,7 @@ func TestTCPTransmitter_SendData_tooBig_realConn(t *testing.T) {
 	}
 	cid := value_object.NewCircuitID()
 	sid := value_object.NewStreamIDAuto()
-	big := make([]byte, 70000)
+        big := make([]byte, value_object.MaxPayloadSize+1)
 	err = tx.SendData(cid, sid, big)
 	if err == nil || err.Error() != "data too big" {
 		t.Errorf("expected data too big error, got %v", err)

--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"ikedadada/go-ptor/internal/domain/entity"
-	"ikedadada/go-ptor/internal/domain/value_object"
+        "ikedadada/go-ptor/internal/domain/value_object"
 	repoimpl "ikedadada/go-ptor/internal/infrastructure/repository"
 	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
 	"ikedadada/go-ptor/internal/usecase"
@@ -29,10 +28,10 @@ func TestRelayUseCase_ExtendAndForward(t *testing.T) {
 	go func() { ln.Accept() }()
 	payload, _ := value_object.EncodeExtendPayload(&value_object.ExtendPayload{NextHop: ln.Addr().String(), EncKey: enc})
 	cid := value_object.NewCircuitID()
-	cell := entity.Cell{CircID: cid, StreamID: 0, Data: payload}
+        cell := &value_object.Cell{Cmd: value_object.CmdExtend, Version: value_object.Version, Payload: payload}
 
 	up1, up2 := net.Pipe()
-	go uc.Handle(up1, cell)
+        go uc.Handle(up1, cid, cell)
 
 	buf := make([]byte, 20)
 	if _, err := io.ReadFull(up2, buf); err != nil {
@@ -55,8 +54,8 @@ func TestRelayUseCase_EndUnknown(t *testing.T) {
 	crypto := infraSvc.NewCryptoService()
 	uc := usecase.NewRelayUseCase(priv, repo, crypto)
 	cid := value_object.NewCircuitID()
-	cell := entity.Cell{CircID: cid, StreamID: 1, End: true}
-	if err := uc.Handle(nil, cell); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+        cell := &value_object.Cell{Cmd: value_object.CmdEnd, Version: value_object.Version, Payload: nil}
+        if err := uc.Handle(nil, cid, cell); err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
 }


### PR DESCRIPTION
## Summary
- transmit fixed-size cells using `value_object.Cell`
- decode incoming cells in relay main
- route commands in relay usecase based on decoded cells
- adjust tests to new frame format

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857a35d70fc832baf97d59606c95531