### PR TITLE
Implement onion encryption for DATA cells

### DIFF
--- a/internal/domain/entity/conn_state.go
+++ b/internal/domain/entity/conn_state.go
@@ -9,19 +9,21 @@ import (
 
 // ConnState represents per-circuit connection information held by a relay.
 type ConnState struct {
-	key  value_object.AESKey
-	up   net.Conn
-	down net.Conn
-	last time.Time
+	key   value_object.AESKey
+	nonce value_object.Nonce
+	up    net.Conn
+	down  net.Conn
+	last  time.Time
 }
 
 // NewConnState returns a new ConnState instance.
-func NewConnState(key value_object.AESKey, up, down net.Conn) *ConnState {
-	return &ConnState{key: key, up: up, down: down, last: time.Now()}
+func NewConnState(key value_object.AESKey, nonce value_object.Nonce, up, down net.Conn) *ConnState {
+	return &ConnState{key: key, nonce: nonce, up: up, down: down, last: time.Now()}
 }
 
 // Key returns the symmetric key for this circuit hop.
-func (s *ConnState) Key() value_object.AESKey { return s.key }
+func (s *ConnState) Key() value_object.AESKey  { return s.key }
+func (s *ConnState) Nonce() value_object.Nonce { return s.nonce }
 
 // Up returns the upstream connection.
 func (s *ConnState) Up() net.Conn { return s.up }

--- a/internal/infrastructure/repository/circuit_table_repository_test.go
+++ b/internal/infrastructure/repository/circuit_table_repository_test.go
@@ -15,7 +15,7 @@ import (
 func TestCircuitTableRepo_AddFindDelete(t *testing.T) {
 	tbl := repoimpl.NewCircuitTableRepository(time.Second)
 	id := value_object.NewCircuitID()
-	st := entity.NewConnState(value_object.AESKey{}, nil, nil)
+	st := entity.NewConnState(value_object.AESKey{}, value_object.Nonce{}, nil, nil)
 	if err := tbl.Add(id, st); err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestCircuitTableRepo_GC(t *testing.T) {
 	tbl := repoimpl.NewCircuitTableRepository(500 * time.Millisecond)
 	id := value_object.NewCircuitID()
 	up, down := net.Pipe()
-	st := entity.NewConnState(value_object.AESKey{}, up, down)
+	st := entity.NewConnState(value_object.AESKey{}, value_object.Nonce{}, up, down)
 	if err := tbl.Add(id, st); err != nil {
 		t.Fatalf("add: %v", err)
 	}

--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -23,7 +23,9 @@ func TestRelayUseCase_ExtendAndForward(t *testing.T) {
 
 	// prepare extend cell
 	key, _ := value_object.NewAESKey()
-	enc, _ := crypto.RSAEncrypt(&priv.PublicKey, key[:])
+	nonce, _ := value_object.NewNonce()
+	msg := append(key[:], nonce[:]...)
+	enc, _ := crypto.RSAEncrypt(&priv.PublicKey, msg)
 	ln, _ := net.Listen("tcp", "127.0.0.1:0")
 	defer ln.Close()
 	go func() { ln.Accept() }()
@@ -68,9 +70,10 @@ func TestRelayUseCase_Connect(t *testing.T) {
 	uc := usecase.NewRelayUseCase(priv, repo, crypto)
 
 	key, _ := value_object.NewAESKey()
+	nonce, _ := value_object.NewNonce()
 	cid := value_object.NewCircuitID()
 	up1, up2 := net.Pipe()
-	st := entity.NewConnState(key, up1, nil)
+	st := entity.NewConnState(key, nonce, up1, nil)
 	repo.Add(cid, st)
 
 	t.Run("ok", func(t *testing.T) {

--- a/internal/usecase/send_data_roundtrip_test.go
+++ b/internal/usecase/send_data_roundtrip_test.go
@@ -1,0 +1,65 @@
+package usecase_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
+	"ikedadada/go-ptor/internal/usecase"
+)
+
+type recordTx struct{ data []byte }
+
+func (r *recordTx) SendData(c value_object.CircuitID, s value_object.StreamID, d []byte) error {
+	r.data = d
+	return nil
+}
+func (r *recordTx) SendEnd(value_object.CircuitID, value_object.StreamID) error { return nil }
+func (r *recordTx) SendDestroy(value_object.CircuitID) error                    { return nil }
+
+func TestSendData_OnionRoundTrip(t *testing.T) {
+	hops := 3
+	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	ids := make([]value_object.RelayID, hops)
+	keys := make([]value_object.AESKey, hops)
+	nonces := make([]value_object.Nonce, hops)
+	for i := 0; i < hops; i++ {
+		ids[i] = relayID
+		k, _ := value_object.NewAESKey()
+		n, _ := value_object.NewNonce()
+		keys[i] = k
+		nonces[i] = n
+	}
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	cir, err := entity.NewCircuit(value_object.NewCircuitID(), ids, keys, nonces, priv)
+	if err != nil {
+		t.Fatalf("circuit: %v", err)
+	}
+	st, _ := cir.OpenStream()
+
+	repo := &mockCircuitRepoSend{circuit: cir}
+	tx := &recordTx{}
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewSendDataUsecase(repo, tx, crypto)
+	data := []byte("hello")
+	if _, err := uc.Handle(usecase.SendDataInput{CircuitID: cir.ID().String(), StreamID: st.ID.UInt16(), Data: data}); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	k2 := make([][32]byte, hops)
+	n2 := make([][12]byte, hops)
+	for i := 0; i < hops; i++ {
+		k2[i] = keys[i]
+		n2[i] = nonces[i]
+	}
+	out, err := crypto.AESMultiOpen(k2, n2, tx.data)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(out) != string(data) {
+		t.Errorf("round-trip mismatch")
+	}
+}

--- a/internal/usecase/send_data_usecase_test.go
+++ b/internal/usecase/send_data_usecase_test.go
@@ -7,6 +7,7 @@ import (
 	"ikedadada/go-ptor/internal/domain/entity"
 	"ikedadada/go-ptor/internal/domain/repository"
 	"ikedadada/go-ptor/internal/domain/value_object"
+	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
 	"ikedadada/go-ptor/internal/usecase"
 	"ikedadada/go-ptor/internal/usecase/service"
 )
@@ -61,7 +62,7 @@ func TestSendDataInteractor_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := usecase.NewSendDataUsecase(tt.repo, tt.tx)
+			uc := usecase.NewSendDataUsecase(tt.repo, tt.tx, infraSvc.NewCryptoService())
 			_, err := uc.Handle(tt.input)
 			if tt.expectsErr && err == nil {
 				t.Errorf("expected error")


### PR DESCRIPTION
## Summary
- add per-hop nonce support in `ConnState`
- encrypt DATA payloads with `AESMultiSeal`
- store hop nonce when extending circuits
- update relay decryption to use stored nonce
- add round-trip test for onion encrypted DATA

## Testing
- `go test ./internal/usecase -run TestSendData_OnionRoundTrip -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857abf1bb38832b81f2a6a3b168b6dd