### PR TITLE
Implement circuit termination flows

### DIFF
--- a/internal/usecase/close_stream_usecase.go
+++ b/internal/usecase/close_stream_usecase.go
@@ -52,5 +52,10 @@ func (uc *closeStreamUsecaseImpl) Handle(in CloseStreamInput) (CloseStreamOutput
 	if err := uc.tx.SendEnd(cid, sid); err != nil { // END セル送信
 		return CloseStreamOutput{}, err
 	}
+	if len(cir.ActiveStreams()) == 0 { // 最後のストリームなら制御 END
+		if err := uc.tx.SendEnd(cid, 0); err != nil {
+			return CloseStreamOutput{}, err
+		}
+	}
 	return CloseStreamOutput{Closed: true}, nil
 }


### PR DESCRIPTION
## Summary
- auto send control END when closing final stream
- verify DestroyCircuitUsecase order and cleanup
- forward END/DESTROY in relay use case and drop connection
- test termination logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857b0e4f048832bbe950bdd660e3dc2