### PR TITLE
Add connection logging across commands

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -20,11 +20,14 @@ import (
 )
 
 func fetchRelays(base string) (map[string]entity.RelayInfo, error) {
-	res, err := http.Get(strings.TrimRight(base, "/") + "/relays.json")
+	url := strings.TrimRight(base, "/") + "/relays.json"
+	log.Printf("request GET %s", url)
+	res, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
+	log.Printf("response GET %s status=%s", url, res.Status)
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status: %s", res.Status)
 	}
@@ -36,11 +39,14 @@ func fetchRelays(base string) (map[string]entity.RelayInfo, error) {
 }
 
 func fetchHidden(base string) (map[string]entity.HiddenServiceInfo, error) {
-	res, err := http.Get(strings.TrimRight(base, "/") + "/hidden.json")
+	url := strings.TrimRight(base, "/") + "/hidden.json"
+	log.Printf("request GET %s", url)
+	res, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
+	log.Printf("response GET %s status=%s", url, res.Status)
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status: %s", res.Status)
 	}
@@ -161,7 +167,11 @@ func main() {
 			log.Println("accept error:", err)
 			continue
 		}
-		go handleSOCKS(c, dir, out.CircuitID, openUC, closeUC)
+		log.Printf("request connection from %s", c.RemoteAddr())
+		go func(conn net.Conn) {
+			handleSOCKS(conn, dir, out.CircuitID, openUC, closeUC)
+			log.Printf("response connection closed %s", conn.RemoteAddr())
+		}(c)
 	}
 }
 

--- a/cmd/directory/main.go
+++ b/cmd/directory/main.go
@@ -25,12 +25,16 @@ func loadDirectory(path string) (entity.Directory, error) {
 func newMux(d entity.Directory) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/relays.json", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("request %s %s", r.Method, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(entity.Directory{Relays: d.Relays})
+		log.Printf("response %s %s %d", r.Method, r.URL.Path, http.StatusOK)
 	})
 	mux.HandleFunc("/hidden.json", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("request %s %s", r.Method, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(entity.Directory{HiddenServices: d.HiddenServices})
+		log.Printf("response %s %s %d", r.Method, r.URL.Path, http.StatusOK)
 	})
 	return mux
 }

--- a/cmd/hidden/main.go
+++ b/cmd/hidden/main.go
@@ -57,7 +57,11 @@ func main() {
 		if err != nil {
 			continue
 		}
-		go io.Copy(c, c)
+		log.Printf("request connection from %s", c.RemoteAddr())
+		go func(conn net.Conn) {
+			io.Copy(conn, conn)
+			log.Printf("response connection closed %s", conn.RemoteAddr())
+		}(c)
 	}
 }
 

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -50,7 +50,11 @@ func main() {
 		if err != nil {
 			continue
 		}
-		go handleConn(c, uc)
+		log.Printf("request connection from %s", c.RemoteAddr())
+		go func(conn net.Conn) {
+			handleConn(conn, uc)
+			log.Printf("response connection closed %s", conn.RemoteAddr())
+		}(c)
 	}
 }
 

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"encoding/binary"
 	"errors"
+	"log"
 	"net"
 
 	"ikedadada/go-ptor/internal/domain/entity"
@@ -132,7 +133,11 @@ func sendAck(w net.Conn, cid value_object.CircuitID) error {
 	copy(buf[:16], cid.Bytes())
 	binary.BigEndian.PutUint16(buf[18:20], 0)
 	_, err := w.Write(buf[:])
-	return err
+	if err != nil {
+		return err
+	}
+	log.Printf("response ack cid=%s", cid.String())
+	return nil
 }
 
 func forwardCell(w net.Conn, cid value_object.CircuitID, cell *value_object.Cell) error {
@@ -142,5 +147,9 @@ func forwardCell(w net.Conn, cid value_object.CircuitID, cell *value_object.Cell
 	}
 	out := append(cid.Bytes(), buf...)
 	_, err = w.Write(out)
-	return err
+	if err != nil {
+		return err
+	}
+	log.Printf("response forward cid=%s cmd=%d len=%d", cid.String(), cell.Cmd, len(cell.Payload))
+	return nil
 }


### PR DESCRIPTION
## Summary
- log HTTP requests/responses in client when fetching directory data
- log directory server requests/responses
- log relay connection accept/close events in hidden service
- log outgoing relay ACKs and forwarded cells
- log connection accept/close in SOCKS5 proxy and relay server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857b4bcf000832b84eb329989d10b2a