### PR TITLE
Relay stream table foundation

### DIFF
--- a/relay/internal/connstate/stream_table.go
+++ b/relay/internal/connstate/stream_table.go
@@ -1,0 +1,69 @@
+package connstate
+
+import (
+	"errors"
+	"net"
+	"sync"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+var (
+	ErrDuplicate = errors.New("stream id already exists")
+	ErrNotFound  = errors.New("stream id not found")
+)
+
+type StreamTable struct {
+	mu sync.RWMutex
+	m  map[value_object.StreamID]net.Conn
+}
+
+func NewStreamTable() *StreamTable {
+	return &StreamTable{m: make(map[value_object.StreamID]net.Conn)}
+}
+
+func (t *StreamTable) Add(id value_object.StreamID, c net.Conn) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.m[id]; ok {
+		return ErrDuplicate
+	}
+	t.m[id] = c
+	return nil
+}
+
+func (t *StreamTable) Get(id value_object.StreamID) (net.Conn, error) {
+	t.mu.RLock()
+	c, ok := t.m[id]
+	t.mu.RUnlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return c, nil
+}
+
+func (t *StreamTable) Remove(id value_object.StreamID) error {
+	t.mu.Lock()
+	c, ok := t.m[id]
+	if !ok {
+		t.mu.Unlock()
+		return ErrNotFound
+	}
+	delete(t.m, id)
+	t.mu.Unlock()
+	if c != nil {
+		c.Close()
+	}
+	return nil
+}
+
+func (t *StreamTable) DestroyAll() {
+	t.mu.Lock()
+	for id, c := range t.m {
+		if c != nil {
+			c.Close()
+		}
+		delete(t.m, id)
+	}
+	t.mu.Unlock()
+}

--- a/relay/internal/connstate/stream_table_test.go
+++ b/relay/internal/connstate/stream_table_test.go
@@ -1,0 +1,52 @@
+package connstate_test
+
+import (
+	"net"
+	"testing"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/relay/internal/connstate"
+)
+
+func TestStreamTable_AddGetRemove(t *testing.T) {
+	tbl := connstate.NewStreamTable()
+	id := value_object.NewStreamIDAuto()
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	if err := tbl.Add(id, c1); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := tbl.Add(id, c2); err != connstate.ErrDuplicate {
+		t.Fatalf("expect ErrDuplicate")
+	}
+	got, err := tbl.Get(id)
+	if err != nil || got != c1 {
+		t.Fatalf("get: %v", err)
+	}
+	if err := tbl.Remove(id); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := tbl.Get(id); err != connstate.ErrNotFound {
+		t.Fatalf("expected ErrNotFound")
+	}
+}
+
+func TestStreamTable_DestroyAll(t *testing.T) {
+	tbl := connstate.NewStreamTable()
+	id1 := value_object.NewStreamIDAuto()
+	id2 := value_object.NewStreamIDAuto()
+	c1, _ := net.Pipe()
+	c2, _ := net.Pipe()
+
+	_ = tbl.Add(id1, c1)
+	_ = tbl.Add(id2, c2)
+	tbl.DestroyAll()
+
+	if _, err := tbl.Get(id1); err != connstate.ErrNotFound {
+		t.Fatalf("table not cleared")
+	}
+	if _, err := tbl.Get(id2); err != connstate.ErrNotFound {
+		t.Fatalf("table not cleared")
+	}
+}


### PR DESCRIPTION
## Summary
- add a `StreamTable` package for relays
- manage stream connections with add/get/remove/destroy helpers
- basic unit tests for the table

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857bb1afacc832b91bb9a16146d13da