### PR TITLE
Add stream-level handling to relay

### DIFF
--- a/internal/domain/entity/conn_state.go
+++ b/internal/domain/entity/conn_state.go
@@ -14,11 +14,12 @@ type ConnState struct {
 	up    net.Conn
 	down  net.Conn
 	last  time.Time
+	tbl   *StreamTable
 }
 
 // NewConnState returns a new ConnState instance.
 func NewConnState(key value_object.AESKey, nonce value_object.Nonce, up, down net.Conn) *ConnState {
-	return &ConnState{key: key, nonce: nonce, up: up, down: down, last: time.Now()}
+	return &ConnState{key: key, nonce: nonce, up: up, down: down, last: time.Now(), tbl: NewStreamTable()}
 }
 
 // Key returns the symmetric key for this circuit hop.
@@ -30,6 +31,9 @@ func (s *ConnState) Up() net.Conn { return s.up }
 
 // Down returns the downstream connection.
 func (s *ConnState) Down() net.Conn { return s.down }
+
+// Streams returns the table of open stream connections.
+func (s *ConnState) Streams() *StreamTable { return s.tbl }
 
 // Touch updates the last-used time to now.
 func (s *ConnState) Touch() { s.last = time.Now() }
@@ -44,5 +48,8 @@ func (s *ConnState) Close() {
 	}
 	if s.down != nil {
 		s.down.Close()
+	}
+	if s.tbl != nil {
+		s.tbl.DestroyAll()
 	}
 }

--- a/internal/domain/entity/stream_table.go
+++ b/internal/domain/entity/stream_table.go
@@ -1,0 +1,69 @@
+package entity
+
+import (
+	"errors"
+	"net"
+	"sync"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+var (
+	ErrDuplicate = errors.New("stream id already exists")
+	ErrNotFound  = errors.New("stream id not found")
+)
+
+type StreamTable struct {
+	mu sync.RWMutex
+	m  map[value_object.StreamID]net.Conn
+}
+
+func NewStreamTable() *StreamTable {
+	return &StreamTable{m: make(map[value_object.StreamID]net.Conn)}
+}
+
+func (t *StreamTable) Add(id value_object.StreamID, c net.Conn) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.m[id]; ok {
+		return ErrDuplicate
+	}
+	t.m[id] = c
+	return nil
+}
+
+func (t *StreamTable) Get(id value_object.StreamID) (net.Conn, error) {
+	t.mu.RLock()
+	c, ok := t.m[id]
+	t.mu.RUnlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return c, nil
+}
+
+func (t *StreamTable) Remove(id value_object.StreamID) error {
+	t.mu.Lock()
+	c, ok := t.m[id]
+	if !ok {
+		t.mu.Unlock()
+		return ErrNotFound
+	}
+	delete(t.m, id)
+	t.mu.Unlock()
+	if c != nil {
+		c.Close()
+	}
+	return nil
+}
+
+func (t *StreamTable) DestroyAll() {
+	t.mu.Lock()
+	for id, c := range t.m {
+		if c != nil {
+			c.Close()
+		}
+		delete(t.m, id)
+	}
+	t.mu.Unlock()
+}

--- a/internal/domain/entity/stream_table_test.go
+++ b/internal/domain/entity/stream_table_test.go
@@ -1,0 +1,52 @@
+package entity_test
+
+import (
+	"net"
+	"testing"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+func TestStreamTable_AddGetRemove(t *testing.T) {
+	tbl := entity.NewStreamTable()
+	id := value_object.NewStreamIDAuto()
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	if err := tbl.Add(id, c1); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := tbl.Add(id, c2); err != entity.ErrDuplicate {
+		t.Fatalf("expect ErrDuplicate")
+	}
+	got, err := tbl.Get(id)
+	if err != nil || got != c1 {
+		t.Fatalf("get: %v", err)
+	}
+	if err := tbl.Remove(id); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := tbl.Get(id); err != entity.ErrNotFound {
+		t.Fatalf("expected ErrNotFound")
+	}
+}
+
+func TestStreamTable_DestroyAll(t *testing.T) {
+	tbl := entity.NewStreamTable()
+	id1 := value_object.NewStreamIDAuto()
+	id2 := value_object.NewStreamIDAuto()
+	c1, _ := net.Pipe()
+	c2, _ := net.Pipe()
+
+	_ = tbl.Add(id1, c1)
+	_ = tbl.Add(id2, c2)
+	tbl.DestroyAll()
+
+	if _, err := tbl.Get(id1); err != entity.ErrNotFound {
+		t.Fatalf("table not cleared")
+	}
+	if _, err := tbl.Get(id2); err != entity.ErrNotFound {
+		t.Fatalf("table not cleared")
+	}
+}

--- a/internal/domain/value_object/begin_payload.go
+++ b/internal/domain/value_object/begin_payload.go
@@ -1,0 +1,26 @@
+package value_object
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+// BeginPayload specifies the target address for a new stream.
+type BeginPayload struct {
+	StreamID uint16
+	Target   string
+}
+
+// EncodeBeginPayload encodes p using gob.
+func EncodeBeginPayload(p *BeginPayload) ([]byte, error) {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(p)
+	return buf.Bytes(), err
+}
+
+// DecodeBeginPayload decodes bytes into a BeginPayload.
+func DecodeBeginPayload(b []byte) (*BeginPayload, error) {
+	var p BeginPayload
+	err := gob.NewDecoder(bytes.NewReader(b)).Decode(&p)
+	return &p, err
+}

--- a/internal/domain/value_object/cell.go
+++ b/internal/domain/value_object/cell.go
@@ -9,11 +9,13 @@ import (
 const (
 	Version byte = 0x01
 
-	CmdExtend  byte = 0x01
-	CmdConnect byte = 0x02
-	CmdData    byte = 0x03
-	CmdEnd     byte = 0x04
-	CmdDestroy byte = 0x05
+	CmdExtend   byte = 0x01
+	CmdConnect  byte = 0x02
+	CmdData     byte = 0x03
+	CmdEnd      byte = 0x04
+	CmdDestroy  byte = 0x05
+	CmdBegin    byte = 0x06
+	CmdBeginAck byte = 0x07
 
 	MaxPayloadSize = MaxCellSize - headerOverhead
 )


### PR DESCRIPTION
## Summary
- allow multiple streams per circuit with `StreamTable`
- include stream table in `ConnState` and new BEGIN payload
- support BEGIN, DATA routing, and END cleanup in relay usecase
- register new cell opcodes for BEGIN and BEGIN_ACK

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857c13ddaac832b914b13c82e2faec8