### PR TITLE
Implement BEGIN streaming via SendDataUsecase

### DIFF
--- a/internal/infrastructure/service/mem_transmitter.go
+++ b/internal/infrastructure/service/mem_transmitter.go
@@ -20,6 +20,10 @@ func (tx *MemTransmitter) SendData(c value_object.CircuitID, s value_object.Stre
 	tx.Out <- fmt.Sprintf("DATA cid=%s sid=%d len=%d", c, s, len(d))
 	return nil
 }
+func (tx *MemTransmitter) SendBegin(c value_object.CircuitID, s value_object.StreamID, d []byte) error {
+	tx.Out <- fmt.Sprintf("BEGIN cid=%s sid=%d len=%d", c, s, len(d))
+	return nil
+}
 func (tx *MemTransmitter) SendEnd(c value_object.CircuitID, s value_object.StreamID) error {
 	tx.Out <- fmt.Sprintf("END  cid=%s sid=%d", c, s)
 	return nil

--- a/internal/infrastructure/service/mem_transmitter_test.go
+++ b/internal/infrastructure/service/mem_transmitter_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMemTx_SendData_SendEnd_Destroy(t *testing.T) {
-	ch := make(chan string, 3)
+	ch := make(chan string, 4)
 
 	tx := &service.MemTransmitter{Out: ch}
 	cid := value_object.NewCircuitID()
@@ -21,6 +21,15 @@ func TestMemTx_SendData_SendEnd_Destroy(t *testing.T) {
 	msg := <-ch
 	if msg == "" || msg[:4] != "DATA" {
 		t.Errorf("unexpected SendData message: %q", msg)
+	}
+
+	err = tx.SendBegin(cid, sid, data)
+	if err != nil {
+		t.Fatalf("SendBegin error: %v", err)
+	}
+	msg = <-ch
+	if msg == "" || msg[:5] != "BEGIN" {
+		t.Errorf("unexpected SendBegin message: %q", msg)
 	}
 
 	err = tx.SendEnd(cid, sid)

--- a/internal/infrastructure/service/tcp_transmitter.go
+++ b/internal/infrastructure/service/tcp_transmitter.go
@@ -46,6 +46,13 @@ func (t *TCPTransmitter) SendData(_ value_object.CircuitID, s value_object.Strea
 	return t.send(value_object.CmdData, p)
 }
 
+func (t *TCPTransmitter) SendBegin(_ value_object.CircuitID, _ value_object.StreamID, d []byte) error {
+	if len(d) > value_object.MaxPayloadSize {
+		return fmt.Errorf("data too big")
+	}
+	return t.send(value_object.CmdBegin, d)
+}
+
 func (t *TCPTransmitter) SendEnd(_ value_object.CircuitID, s value_object.StreamID) error {
 	p, err := value_object.EncodeDataPayload(&value_object.DataPayload{StreamID: s.UInt16()})
 	if err != nil {

--- a/internal/infrastructure/service/tcp_transmitter_test.go
+++ b/internal/infrastructure/service/tcp_transmitter_test.go
@@ -80,6 +80,23 @@ func TestTCPTransmitter_SendData_SendEnd_realConn(t *testing.T) {
 		t.Fatal("timeout waiting for SendData")
 	}
 
+	err = tx.SendBegin(cid, sid, data)
+	if err != nil {
+		t.Fatalf("SendBegin error: %v", err)
+	}
+	select {
+	case msg := <-received:
+		cell, err := value_object.Decode(msg)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if cell.Cmd != value_object.CmdBegin {
+			t.Errorf("unexpected cmd %d", cell.Cmd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for SendBegin")
+	}
+
 	err = tx.SendEnd(cid, sid)
 	if err != nil {
 		t.Fatalf("SendEnd error: %v", err)

--- a/internal/usecase/close_stream_usecase_test.go
+++ b/internal/usecase/close_stream_usecase_test.go
@@ -38,6 +38,9 @@ func (m *mockTransmitterClose) SendEnd(c value_object.CircuitID, s value_object.
 	}{c, s})
 	return m.err
 }
+func (m *mockTransmitterClose) SendBegin(value_object.CircuitID, value_object.StreamID, []byte) error {
+	return nil
+}
 func (m *mockTransmitterClose) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return nil
 }

--- a/internal/usecase/destroy_circuit_usecase_test.go
+++ b/internal/usecase/destroy_circuit_usecase_test.go
@@ -41,6 +41,9 @@ type mockTxDestroy struct {
 func (m *mockTxDestroy) SendData(value_object.CircuitID, value_object.StreamID, []byte) error {
 	return nil
 }
+func (m *mockTxDestroy) SendBegin(value_object.CircuitID, value_object.StreamID, []byte) error {
+	return nil
+}
 func (m *mockTxDestroy) SendEnd(_ value_object.CircuitID, s value_object.StreamID) error {
 	m.ends = append(m.ends, s)
 	return nil

--- a/internal/usecase/send_data_roundtrip_test.go
+++ b/internal/usecase/send_data_roundtrip_test.go
@@ -17,6 +17,10 @@ func (r *recordTx) SendData(c value_object.CircuitID, s value_object.StreamID, d
 	r.data = d
 	return nil
 }
+func (r *recordTx) SendBegin(c value_object.CircuitID, s value_object.StreamID, d []byte) error {
+	r.data = d
+	return nil
+}
 func (r *recordTx) SendEnd(value_object.CircuitID, value_object.StreamID) error { return nil }
 func (r *recordTx) SendDestroy(value_object.CircuitID) error                    { return nil }
 
@@ -60,6 +64,50 @@ func TestSendData_OnionRoundTrip(t *testing.T) {
 		t.Fatalf("decrypt: %v", err)
 	}
 	if string(out) != string(data) {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestSendData_BeginRoundTrip(t *testing.T) {
+	hops := 2
+	relayID, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	ids := make([]value_object.RelayID, hops)
+	keys := make([]value_object.AESKey, hops)
+	nonces := make([]value_object.Nonce, hops)
+	for i := 0; i < hops; i++ {
+		ids[i] = relayID
+		k, _ := value_object.NewAESKey()
+		n, _ := value_object.NewNonce()
+		keys[i] = k
+		nonces[i] = n
+	}
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	cir, err := entity.NewCircuit(value_object.NewCircuitID(), ids, keys, nonces, priv)
+	if err != nil {
+		t.Fatalf("circuit: %v", err)
+	}
+	st, _ := cir.OpenStream()
+
+	repo := &mockCircuitRepoSend{circuit: cir}
+	tx := &recordTx{}
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewSendDataUsecase(repo, tx, crypto)
+	payload, _ := value_object.EncodeBeginPayload(&value_object.BeginPayload{StreamID: st.ID.UInt16(), Target: "example.com:80"})
+	if _, err := uc.Handle(usecase.SendDataInput{CircuitID: cir.ID().String(), StreamID: st.ID.UInt16(), Data: payload, Cmd: value_object.CmdBegin}); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	k2 := make([][32]byte, hops)
+	n2 := make([][12]byte, hops)
+	for i := 0; i < hops; i++ {
+		k2[i] = keys[i]
+		n2[i] = nonces[i]
+	}
+	out, err := crypto.AESMultiOpen(k2, n2, tx.data)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(out) != string(payload) {
 		t.Errorf("round-trip mismatch")
 	}
 }

--- a/internal/usecase/send_data_usecase_test.go
+++ b/internal/usecase/send_data_usecase_test.go
@@ -31,6 +31,9 @@ type mockTransmitterSend struct {
 func (m *mockTransmitterSend) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return m.err
 }
+func (m *mockTransmitterSend) SendBegin(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
+	return m.err
+}
 func (m *mockTransmitterSend) SendEnd(c value_object.CircuitID, s value_object.StreamID) error {
 	return nil
 }
@@ -54,6 +57,7 @@ func TestSendDataInteractor_Handle(t *testing.T) {
 		expectsErr bool
 	}{
 		{"ok", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, false},
+		{"begin", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("target"), Cmd: value_object.CmdBegin}, false},
 		{"circuit not found", &mockCircuitRepoSend{circuit: nil, err: errors.New("not found")}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
 		{"bad id", &mockCircuitRepoSend{circuit: nil}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: "bad-uuid", StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
 		{"tx error", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{err: errors.New("fail")}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},

--- a/internal/usecase/service/circuit_transmit_service.go
+++ b/internal/usecase/service/circuit_transmit_service.go
@@ -6,6 +6,7 @@ import "ikedadada/go-ptor/internal/domain/value_object"
 // 回路 ID + ストリーム ID + データを受け取り、セル化してネットワークに送る。
 type CircuitTransmitter interface {
 	SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error
+	SendBegin(c value_object.CircuitID, s value_object.StreamID, data []byte) error
 	SendEnd(c value_object.CircuitID, s value_object.StreamID) error
 	SendDestroy(c value_object.CircuitID) error
 }

--- a/internal/usecase/shutdown_circuit_usecase_test.go
+++ b/internal/usecase/shutdown_circuit_usecase_test.go
@@ -42,6 +42,9 @@ func (m *mockTransmitterShutdown) SendEnd(c value_object.CircuitID, s value_obje
 	}{c, s})
 	return nil
 }
+func (m *mockTransmitterShutdown) SendBegin(value_object.CircuitID, value_object.StreamID, []byte) error {
+	return nil
+}
 func (m *mockTransmitterShutdown) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
- extend CircuitTransmitter with `SendBegin`
- allow `SendDataUsecase` to send BEGIN cells
- rewrite client SOCKS handler to send BEGIN and DATA via use cases
- update transmitters and tests for new method
- add integration test for BEGIN round-trip encryption

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857d892244c832b97425e1afcf9fceb