### PR TITLE
Refactor TCP transmitter to factory pattern

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -152,10 +152,10 @@ func main() {
 	}
 	fmt.Println("Circuit built:", out.CircuitID)
 
-	tx := infraSvc.NewMemTransmitter(make(chan string, 10))
+	factory := infraSvc.TCPTransmitterFactory{}
 	openUC := usecase.NewOpenStreamUsecase(circuitRepository)
-	closeUC := usecase.NewCloseStreamUsecase(circuitRepository, tx)
-	sendUC := usecase.NewSendDataUsecase(circuitRepository, tx, cryptoSvc)
+	closeUC := usecase.NewCloseStreamUsecase(circuitRepository, factory)
+	sendUC := usecase.NewSendDataUsecase(circuitRepository, factory, cryptoSvc)
 	endUC := usecase.NewHandleEndUsecase(circuitRepository)
 
 	ln, err := net.Listen("tcp", *socks)

--- a/internal/infrastructure/service/tcp_transmitter.go
+++ b/internal/infrastructure/service/tcp_transmitter.go
@@ -14,12 +14,10 @@ type TCPTransmitter struct {
 	conn net.Conn
 }
 
-func NewTCPTransmitter(addr string) (service.CircuitTransmitter, error) {
-	c, err := net.Dial("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-	return &TCPTransmitter{conn: c}, nil
+// NewTCPTransmitter wraps an already-connected net.Conn.
+// The caller is responsible for establishing the connection.
+func NewTCPTransmitter(conn net.Conn) service.CircuitTransmitter {
+	return &TCPTransmitter{conn: conn}
 }
 
 func (t *TCPTransmitter) send(cmd byte, payload []byte) error {

--- a/internal/infrastructure/service/tcp_transmitter_factory.go
+++ b/internal/infrastructure/service/tcp_transmitter_factory.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"net"
+
+	useSvc "ikedadada/go-ptor/internal/usecase/service"
+)
+
+// TransmitterFactory produces a CircuitTransmitter bound to a given connection.
+type TransmitterFactory interface {
+	New(conn net.Conn) useSvc.CircuitTransmitter
+}
+
+// TCPTransmitterFactory creates TCPTransmitter instances.
+type TCPTransmitterFactory struct{}
+
+// New returns a CircuitTransmitter using the provided connection.
+func (TCPTransmitterFactory) New(conn net.Conn) useSvc.CircuitTransmitter {
+	return NewTCPTransmitter(conn)
+}

--- a/internal/infrastructure/service/tcp_transmitter_test.go
+++ b/internal/infrastructure/service/tcp_transmitter_test.go
@@ -45,10 +45,11 @@ func TestTCPTransmitter_SendData_SendEnd_realConn(t *testing.T) {
 	addr, received, closeFn := startTestTCPServer(t)
 	defer closeFn()
 
-	tx, err := service.NewTCPTransmitter(addr)
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("Dial error: %v", err)
 	}
+	tx := service.NewTCPTransmitter(conn)
 	cid := value_object.NewCircuitID()
 	sid := value_object.NewStreamIDAuto()
 	data := []byte("hello")
@@ -135,10 +136,11 @@ func TestTCPTransmitter_SendData_SendEnd_realConn(t *testing.T) {
 func TestTCPTransmitter_SendData_tooBig_realConn(t *testing.T) {
 	addr, _, closeFn := startTestTCPServer(t)
 	defer closeFn()
-	tx, err := service.NewTCPTransmitter(addr)
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("Dial error: %v", err)
 	}
+	tx := service.NewTCPTransmitter(conn)
 	cid := value_object.NewCircuitID()
 	sid := value_object.NewStreamIDAuto()
 	big := make([]byte, value_object.MaxPayloadSize+1)

--- a/internal/usecase/send_data_usecase_test.go
+++ b/internal/usecase/send_data_usecase_test.go
@@ -2,6 +2,7 @@ package usecase_test
 
 import (
 	"errors"
+	"net"
 	"testing"
 
 	"ikedadada/go-ptor/internal/domain/entity"
@@ -24,9 +25,7 @@ func (m *mockCircuitRepoSend) Save(*entity.Circuit) error             { return n
 func (m *mockCircuitRepoSend) Delete(value_object.CircuitID) error    { return nil }
 func (m *mockCircuitRepoSend) ListActive() ([]*entity.Circuit, error) { return nil, nil }
 
-type mockTransmitterSend struct {
-	err error
-}
+type mockTransmitterSend struct{ err error }
 
 func (m *mockTransmitterSend) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return m.err
@@ -38,6 +37,10 @@ func (m *mockTransmitterSend) SendEnd(c value_object.CircuitID, s value_object.S
 	return nil
 }
 func (m *mockTransmitterSend) SendDestroy(value_object.CircuitID) error { return nil }
+
+type sendFactory struct{ tx service.CircuitTransmitter }
+
+func (m sendFactory) New(net.Conn) service.CircuitTransmitter { return m.tx }
 
 func TestSendDataInteractor_Handle(t *testing.T) {
 	circuit, err := makeTestCircuit()
@@ -52,21 +55,21 @@ func TestSendDataInteractor_Handle(t *testing.T) {
 	tests := []struct {
 		name       string
 		repo       repository.CircuitRepository
-		tx         service.CircuitTransmitter
+		fac        infraSvc.TransmitterFactory
 		input      usecase.SendDataInput
 		expectsErr bool
 	}{
-		{"ok", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, false},
-		{"begin", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("target"), Cmd: value_object.CmdBegin}, false},
-		{"circuit not found", &mockCircuitRepoSend{circuit: nil, err: errors.New("not found")}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
-		{"bad id", &mockCircuitRepoSend{circuit: nil}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: "bad-uuid", StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
-		{"tx error", &mockCircuitRepoSend{circuit: circuit}, &mockTransmitterSend{err: errors.New("fail")}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
-		{"stream not active", &mockCircuitRepoSend{circuit: &entity.Circuit{}}, &mockTransmitterSend{}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
+		{"ok", &mockCircuitRepoSend{circuit: circuit}, sendFactory{&mockTransmitterSend{}}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, false},
+		{"begin", &mockCircuitRepoSend{circuit: circuit}, sendFactory{&mockTransmitterSend{}}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("target"), Cmd: value_object.CmdBegin}, false},
+		{"circuit not found", &mockCircuitRepoSend{circuit: nil, err: errors.New("not found")}, sendFactory{&mockTransmitterSend{}}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
+		{"bad id", &mockCircuitRepoSend{circuit: nil}, sendFactory{&mockTransmitterSend{}}, usecase.SendDataInput{CircuitID: "bad-uuid", StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
+		{"tx error", &mockCircuitRepoSend{circuit: circuit}, sendFactory{&mockTransmitterSend{err: errors.New("fail")}}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
+		{"stream not active", &mockCircuitRepoSend{circuit: &entity.Circuit{}}, sendFactory{&mockTransmitterSend{}}, usecase.SendDataInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16(), Data: []byte("hello")}, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := usecase.NewSendDataUsecase(tt.repo, tt.tx, infraSvc.NewCryptoService())
+			uc := usecase.NewSendDataUsecase(tt.repo, tt.fac, infraSvc.NewCryptoService())
 			_, err := uc.Handle(tt.input)
 			if tt.expectsErr && err == nil {
 				t.Errorf("expected error")

--- a/internal/usecase/shutdown_circuit_usecase.go
+++ b/internal/usecase/shutdown_circuit_usecase.go
@@ -5,7 +5,7 @@ import (
 
 	"ikedadada/go-ptor/internal/domain/repository"
 	"ikedadada/go-ptor/internal/domain/value_object"
-	"ikedadada/go-ptor/internal/usecase/service"
+	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
 )
 
 // ShutdownCircuitInput specifies which circuit to close gracefully.
@@ -24,13 +24,13 @@ type ShutdownCircuitUseCase interface {
 }
 
 type shutdownCircuitUseCaseImpl struct {
-	repo repository.CircuitRepository
-	tx   service.CircuitTransmitter
+	repo    repository.CircuitRepository
+	factory infraSvc.TransmitterFactory
 }
 
 // NewShutdownCircuitUsecase returns a use case for orderly circuit shutdown.
-func NewShutdownCircuitUsecase(cr repository.CircuitRepository, tx service.CircuitTransmitter) ShutdownCircuitUseCase {
-	return &shutdownCircuitUseCaseImpl{repo: cr, tx: tx}
+func NewShutdownCircuitUsecase(cr repository.CircuitRepository, f infraSvc.TransmitterFactory) ShutdownCircuitUseCase {
+	return &shutdownCircuitUseCaseImpl{repo: cr, factory: f}
 }
 
 // Handle は回路内の全ストリームを END セルで閉じ、制御 END を送ってから
@@ -45,17 +45,18 @@ func (uc *shutdownCircuitUseCaseImpl) Handle(in ShutdownCircuitInput) (ShutdownC
 	if err != nil {
 		return ShutdownCircuitOutput{}, fmt.Errorf("circuit not found: %w", err)
 	}
+	tx := uc.factory.New(cir.Conn(0))
 
 	// --- 2. アクティブストリームを順に閉じる
 	for _, sid := range cir.ActiveStreams() {
 		// ドメイン側を先に更新
 		cir.CloseStream(sid)
 		// ネットワーク側へ END セル
-		_ = uc.tx.SendEnd(cid, sid) // 送信エラーは無視 or 集約
+		_ = tx.SendEnd(cid, sid) // 送信エラーは無視 or 集約
 	}
 
 	// --- 3. 制御ストリーム 0 で回路破棄を通知
-	_ = uc.tx.SendEnd(cid, 0) // StreamID 0 は回路制御専用とする
+	_ = tx.SendEnd(cid, 0) // StreamID 0 は回路制御専用とする
 
 	// --- 4. Repository から削除
 	if err := uc.repo.Delete(cid); err != nil {


### PR DESCRIPTION
## Summary
- create `TransmitterFactory` and `TCPTransmitterFactory`
- update `send` use cases to accept a factory instead of a transmitter
- adjust client wiring to construct a factory
- update tests for new factory behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857e3ba22bc832bb05ad5ce7e9d6bee