### PR TITLE
Handle EXTEND forwarding for existing circuits

### DIFF
--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -56,6 +56,62 @@ func TestRelayUseCase_ExtendAndForward(t *testing.T) {
 	st.Up().Close()
 }
 
+func TestRelayUseCase_ForwardExtendExisting(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	repo := repoimpl.NewCircuitTableRepository(time.Second)
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewRelayUseCase(priv, repo, crypto)
+
+	key, _ := value_object.NewAESKey()
+	nonce, _ := value_object.NewNonce()
+	cid := value_object.NewCircuitID()
+	up1, up2 := net.Pipe()
+	down1, down2 := net.Pipe()
+	st := entity.NewConnState(key, nonce, up1, down1)
+	repo.Add(cid, st)
+
+	_, pub, _ := crypto.X25519Generate()
+	var pubArr [32]byte
+	copy(pubArr[:], pub)
+	payload, _ := value_object.EncodeExtendPayload(&value_object.ExtendPayload{ClientPub: pubArr})
+	cell := &value_object.Cell{Cmd: value_object.CmdExtend, Version: value_object.Version, Payload: payload}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- uc.Handle(up1, cid, cell) }()
+
+	fwd := make([]byte, 528)
+	if _, err := io.ReadFull(down2, fwd); err != nil {
+		t.Fatalf("read forward: %v", err)
+	}
+	if fwd[16] != value_object.CmdExtend {
+		t.Fatalf("forwarded cmd %d", fwd[16])
+	}
+
+	created, _ := value_object.EncodeCreatedPayload(&value_object.CreatedPayload{RelayPub: pubArr})
+	var hdr [20]byte
+	copy(hdr[:16], cid.Bytes())
+	binary.BigEndian.PutUint16(hdr[18:20], uint16(len(created)))
+	down2.Write(hdr[:])
+	down2.Write(created)
+
+	var respHdr [20]byte
+	if _, err := io.ReadFull(up2, respHdr[:]); err != nil {
+		t.Fatalf("read created hdr: %v", err)
+	}
+	l := binary.BigEndian.Uint16(respHdr[18:20])
+	resp := make([]byte, l)
+	if _, err := io.ReadFull(up2, resp); err != nil {
+		t.Fatalf("read created body: %v", err)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	st.Up().Close()
+	st.Down().Close()
+}
+
 func TestRelayUseCase_EndUnknown(t *testing.T) {
 	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
 	repo := repoimpl.NewCircuitTableRepository(time.Second)


### PR DESCRIPTION
## Summary
- forward EXTEND cells through existing circuits
- relay CREATED responses upstream
- test forwarding EXTEND for established circuit hops

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6859354f7894832bbb37ab36049bcb52