### PR TITLE
Expose hidden service

### DIFF
--- a/cmd/hidden/main.go
+++ b/cmd/hidden/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	keyPath := flag.String("key", "hidden.pem", "ED25519 private key")
-	listen := flag.String("listen", "127.0.0.1:5000", "relay listen address (localhost only)")
+	listen := flag.String("listen", ":5000", "relay listen address")
 	httpAddr := flag.String("http", "127.0.0.1:8080", "HTTP service address")
 	flag.Parse()
 
@@ -29,13 +29,11 @@ func main() {
 		host = "0.0.0.0"
 	}
 	ip := net.ParseIP(host)
-	if ip == nil {
-		if strings.EqualFold(host, "localhost") {
-			ip = net.ParseIP("127.0.0.1")
-		}
+	if ip == nil && strings.EqualFold(host, "localhost") {
+		ip = net.ParseIP("127.0.0.1")
 	}
-	if ip == nil || !ip.IsLoopback() {
-		log.Fatal("hidden service must listen on localhost only")
+	if ip == nil || !(ip.IsLoopback() || ip.IsUnspecified()) {
+		log.Fatal("hidden service must listen on loopback or unspecified address")
 	}
 
 	priv, err := loadEDPriv(*keyPath)

--- a/compose.yml
+++ b/compose.yml
@@ -51,6 +51,7 @@ services:
     ports:
       - "5003:5000"
       - "8080:8080"
+    command: ["-listen", ":5000"]
     depends_on:
       - relay3
     networks:

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 
 	"ikedadada/go-ptor/internal/domain/entity"
 	repoif "ikedadada/go-ptor/internal/domain/repository"
@@ -67,7 +68,10 @@ func (uc *relayUsecaseImpl) Handle(up net.Conn, cid value_object.CircuitID, cell
 }
 
 func (uc *relayUsecaseImpl) connect(st *entity.ConnState, cid value_object.CircuitID, cell *value_object.Cell) error {
-	addr := "127.0.0.1:5003"
+	addr := os.Getenv("HIDDEN_ADDR")
+	if addr == "" {
+		addr = "hidden:5000"
+	}
 	if len(cell.Payload) > 0 {
 		p, err := value_object.DecodeConnectPayload(cell.Payload)
 		if err != nil {


### PR DESCRIPTION
## Summary
- allow hidden service to listen on all interfaces
- update compose config for hidden service
- default connect target to `hidden:5000` (or `$HIDDEN_ADDR`)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68689f9a20dc832ba292c973e4b27888