### PR TITLE
Allow hidden service to listen on unspecified address

### DIFF
--- a/cmd/hidden/main.go
+++ b/cmd/hidden/main.go
@@ -16,6 +16,8 @@ import (
 
 func main() {
 	keyPath := flag.String("key", "hidden.pem", "ED25519 private key")
+	// Default to all interfaces so Docker containers can bind. Validation
+	// below restricts to loopback or unspecified addresses.
 	listen := flag.String("listen", ":5000", "relay listen address")
 	httpAddr := flag.String("http", "127.0.0.1:8080", "HTTP service address")
 	flag.Parse()

--- a/docs/project_plans.md
+++ b/docs/project_plans.md
@@ -741,7 +741,9 @@ func main() {
 
 #### ✅ 外部からの直接アクセスを防ぐには
 
-1. `ptor-hidden` は localhost 限定で Listen
+1. `ptor-hidden` は基本的に localhost で Listen。Docker 展開時は
+   `0.0.0.0` など未指定アドレスに公開してもよいが、
+   外部からの接続はファイアウォールで遮断する。
 2. `firewalld` / `ufw` で tcp/8080 などを外部ブロック
 3. `relay3` 以外からの接続は拒否（IP 制限 or 鍵認証）
 


### PR DESCRIPTION
## Summary
- permit `ptor-hidden` to bind on `0.0.0.0`
- clarify Docker listening behaviour in docs

## Testing
- `go test ./...`
- `docker compose build hidden` *(fails: `docker: command not found`)*
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868a6426884832bb569921c1ff33da0