### PR TITLE
Refactor cell reader into shared handler

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -14,12 +14,10 @@ import (
 	"os"
 	"time"
 
-	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/internal/handler"
 	repoimpl "ikedadada/go-ptor/internal/infrastructure/repository"
 	"ikedadada/go-ptor/internal/infrastructure/service"
 	"ikedadada/go-ptor/internal/usecase"
-
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -61,7 +59,7 @@ func main() {
 func handleConn(c net.Conn, uc usecase.RelayUseCase) {
 	defer c.Close()
 	for {
-		cid, cell, err := readCell(c)
+		cid, cell, err := handler.ReadCell(c)
 		if err != nil {
 			if err != io.EOF {
 				log.Println("read cell:", err)
@@ -73,30 +71,6 @@ func handleConn(c net.Conn, uc usecase.RelayUseCase) {
 			log.Println("handle:", err)
 		}
 	}
-}
-
-// readCell reads the cell header and returns the payload as-is. The payload
-// may still be encrypted; decryption is performed by RelayUseCase.
-func readCell(r io.Reader) (value_object.CircuitID, *value_object.Cell, error) {
-	var idBuf [16]byte
-	if _, err := io.ReadFull(r, idBuf[:]); err != nil {
-		return value_object.CircuitID{}, nil, err
-	}
-	var id uuid.UUID
-	copy(id[:], idBuf[:])
-	cid, err := value_object.CircuitIDFrom(id.String())
-	if err != nil {
-		return value_object.CircuitID{}, nil, err
-	}
-	var cellBuf [value_object.MaxCellSize]byte
-	if _, err := io.ReadFull(r, cellBuf[:]); err != nil {
-		return value_object.CircuitID{}, nil, err
-	}
-	cell, err := value_object.Decode(cellBuf[:])
-	if err != nil {
-		return value_object.CircuitID{}, nil, err
-	}
-	return cid, cell, nil
 }
 
 // loadRSAPriv loads an RSA private key from a PEM file.

--- a/cmd/relay/tcp_dialer_sendcell_test.go
+++ b/cmd/relay/tcp_dialer_sendcell_test.go
@@ -8,6 +8,7 @@ import (
 
 	"ikedadada/go-ptor/internal/domain/entity"
 	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/internal/handler"
 	"ikedadada/go-ptor/internal/infrastructure/service"
 )
 
@@ -39,7 +40,7 @@ func TestSendCellWritesFixedPacket(t *testing.T) {
 		t.Fatalf("expected %d bytes, got %d", 16+value_object.MaxCellSize, conn.Len())
 	}
 
-	gotCID, gotCell, err := readCell(bytes.NewReader(conn.Bytes()))
+	gotCID, gotCell, err := handler.ReadCell(bytes.NewReader(conn.Bytes()))
 	if err != nil {
 		t.Fatalf("readCell: %v", err)
 	}

--- a/internal/handler/cell.go
+++ b/internal/handler/cell.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"io"
+
+	"github.com/google/uuid"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+)
+
+// ReadCell reads a circuit ID followed by a value_object.Cell from r.
+// The payload is returned as-is and may still be encrypted.
+func ReadCell(r io.Reader) (value_object.CircuitID, *value_object.Cell, error) {
+	var idBuf [16]byte
+	if _, err := io.ReadFull(r, idBuf[:]); err != nil {
+		return value_object.CircuitID{}, nil, err
+	}
+	var id uuid.UUID
+	copy(id[:], idBuf[:])
+	cid, err := value_object.CircuitIDFrom(id.String())
+	if err != nil {
+		return value_object.CircuitID{}, nil, err
+	}
+	var cellBuf [value_object.MaxCellSize]byte
+	if _, err := io.ReadFull(r, cellBuf[:]); err != nil {
+		return value_object.CircuitID{}, nil, err
+	}
+	cell, err := value_object.Decode(cellBuf[:])
+	if err != nil {
+		return value_object.CircuitID{}, nil, err
+	}
+	return cid, cell, nil
+}

--- a/internal/handler/cell_test.go
+++ b/internal/handler/cell_test.go
@@ -1,0 +1,35 @@
+package handler_test
+
+import (
+	"bytes"
+	"testing"
+
+	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/internal/handler"
+)
+
+func TestReadCell(t *testing.T) {
+	cid := value_object.NewCircuitID()
+	cellBuf, err := value_object.Encode(value_object.Cell{Cmd: value_object.CmdData, Version: value_object.Version, Payload: []byte("hi")})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	buf := append(cid.Bytes(), cellBuf...)
+	gotCID, gotCell, err := handler.ReadCell(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !cid.Equal(gotCID) {
+		t.Fatalf("cid mismatch")
+	}
+	if gotCell.Cmd != value_object.CmdData || string(gotCell.Payload) != "hi" {
+		t.Fatalf("cell mismatch")
+	}
+}
+
+func TestReadCell_Err(t *testing.T) {
+	_, _, err := handler.ReadCell(bytes.NewReader([]byte("short")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- share the cell-reading logic via `internal/handler.ReadCell`
- use the helper in relay and client
- test the helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6868db075de0832b8800e2559a8f4d7b