### PR TITLE
Add CONNECT handling to transmitter and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,16 @@ For example, to start the client:
 go run ./cmd/client
 ```
 
+When the client resolves a `.ptor` address, it sends a CONNECT cell once for the
+current circuit before any streams are opened. After the CONNECT succeeds,
+stream data continues to use BEGIN cells as before.
+
 ### Environment variables
 
-The relay uses the `PTOR_HIDDEN_ADDR` variable to locate the hidden HTTP service.
-If not set, it falls back to `hidden:5000`, which matches the Docker demo.
+The relay uses the `PTOR_HIDDEN_ADDR` variable to locate the hidden HTTP service
+when processing CONNECT cells. If not set, it falls back to `hidden:5000` (the
+Docker demo value). The older `HIDDEN_ADDR` variable is also checked for
+backward compatibility.
 
 ## Testing
 

--- a/internal/infrastructure/service/mem_transmitter.go
+++ b/internal/infrastructure/service/mem_transmitter.go
@@ -24,6 +24,10 @@ func (tx *MemTransmitter) SendBegin(c value_object.CircuitID, s value_object.Str
 	tx.Out <- fmt.Sprintf("BEGIN cid=%s sid=%d len=%d", c, s, len(d))
 	return nil
 }
+func (tx *MemTransmitter) SendConnect(c value_object.CircuitID, d []byte) error {
+	tx.Out <- fmt.Sprintf("CONNECT cid=%s len=%d", c, len(d))
+	return nil
+}
 func (tx *MemTransmitter) SendEnd(c value_object.CircuitID, s value_object.StreamID) error {
 	tx.Out <- fmt.Sprintf("END  cid=%s sid=%d", c, s)
 	return nil

--- a/internal/infrastructure/service/mem_transmitter_test.go
+++ b/internal/infrastructure/service/mem_transmitter_test.go
@@ -32,6 +32,15 @@ func TestMemTx_SendData_SendEnd_Destroy(t *testing.T) {
 		t.Errorf("unexpected SendBegin message: %q", msg)
 	}
 
+	err = tx.SendConnect(cid, []byte("target"))
+	if err != nil {
+		t.Fatalf("SendConnect error: %v", err)
+	}
+	msg = <-ch
+	if msg == "" || msg[:7] != "CONNECT" {
+		t.Errorf("unexpected SendConnect message: %q", msg)
+	}
+
 	err = tx.SendEnd(cid, sid)
 	if err != nil {
 		t.Fatalf("SendEnd error: %v", err)

--- a/internal/infrastructure/service/tcp_transmitter.go
+++ b/internal/infrastructure/service/tcp_transmitter.go
@@ -52,6 +52,13 @@ func (t *TCPTransmitter) SendBegin(cid value_object.CircuitID, _ value_object.St
 	return t.send(value_object.CmdBegin, cid, d)
 }
 
+func (t *TCPTransmitter) SendConnect(cid value_object.CircuitID, d []byte) error {
+	if len(d) > value_object.MaxPayloadSize {
+		return fmt.Errorf("data too big")
+	}
+	return t.send(value_object.CmdConnect, cid, d)
+}
+
 func (t *TCPTransmitter) SendEnd(cid value_object.CircuitID, s value_object.StreamID) error {
 	p, err := value_object.EncodeDataPayload(&value_object.DataPayload{StreamID: s.UInt16()})
 	if err != nil {

--- a/internal/infrastructure/service/tcp_transmitter_test.go
+++ b/internal/infrastructure/service/tcp_transmitter_test.go
@@ -115,6 +115,26 @@ func TestTCPTransmitter_SendData_SendEnd_realConn(t *testing.T) {
 		t.Fatal("timeout waiting for SendBegin")
 	}
 
+	err = tx.SendConnect(cid, []byte("target"))
+	if err != nil {
+		t.Fatalf("SendConnect error: %v", err)
+	}
+	select {
+	case msg := <-received:
+		if len(msg) != 16+value_object.MaxCellSize {
+			t.Fatalf("unexpected cell size %d", len(msg))
+		}
+		cell, err := value_object.Decode(msg[16:])
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if cell.Cmd != value_object.CmdConnect {
+			t.Errorf("expected CONNECT cmd, got %d", cell.Cmd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for SendConnect")
+	}
+
 	err = tx.SendEnd(cid, sid)
 	if err != nil {
 		t.Fatalf("SendEnd error: %v", err)

--- a/internal/usecase/close_stream_usecase_test.go
+++ b/internal/usecase/close_stream_usecase_test.go
@@ -46,7 +46,8 @@ func (m *mockTransmitterClose) SendBegin(value_object.CircuitID, value_object.St
 func (m *mockTransmitterClose) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return nil
 }
-func (m *mockTransmitterClose) SendDestroy(value_object.CircuitID) error { return nil }
+func (m *mockTransmitterClose) SendDestroy(value_object.CircuitID) error         { return nil }
+func (m *mockTransmitterClose) SendConnect(value_object.CircuitID, []byte) error { return nil }
 
 type closeFactory struct{ tx service.CircuitTransmitter }
 

--- a/internal/usecase/connect_usecase_test.go
+++ b/internal/usecase/connect_usecase_test.go
@@ -1,0 +1,105 @@
+package usecase_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net"
+	"testing"
+
+	"ikedadada/go-ptor/internal/domain/entity"
+	"ikedadada/go-ptor/internal/domain/repository"
+	"ikedadada/go-ptor/internal/domain/value_object"
+	"ikedadada/go-ptor/internal/usecase"
+	useSvc "ikedadada/go-ptor/internal/usecase/service"
+)
+
+type mockRepoConnect struct {
+	circuit *entity.Circuit
+	err     error
+}
+
+func (m *mockRepoConnect) Find(id value_object.CircuitID) (*entity.Circuit, error) {
+	return m.circuit, m.err
+}
+func (m *mockRepoConnect) Save(*entity.Circuit) error             { return nil }
+func (m *mockRepoConnect) Delete(value_object.CircuitID) error    { return nil }
+func (m *mockRepoConnect) ListActive() ([]*entity.Circuit, error) { return nil, nil }
+
+type mockTxConnect struct {
+	cid     value_object.CircuitID
+	payload []byte
+	err     error
+}
+
+func (m *mockTxConnect) SendData(value_object.CircuitID, value_object.StreamID, []byte) error {
+	return nil
+}
+func (m *mockTxConnect) SendBegin(value_object.CircuitID, value_object.StreamID, []byte) error {
+	return nil
+}
+func (m *mockTxConnect) SendConnect(c value_object.CircuitID, d []byte) error {
+	m.cid = c
+	m.payload = d
+	return m.err
+}
+func (m *mockTxConnect) SendEnd(value_object.CircuitID, value_object.StreamID) error { return nil }
+func (m *mockTxConnect) SendDestroy(value_object.CircuitID) error                    { return nil }
+
+type connectFactory struct{ tx *mockTxConnect }
+
+func (c connectFactory) New(net.Conn) useSvc.CircuitTransmitter { return c.tx }
+
+func makeTestCircuitConnect() (*entity.Circuit, error) {
+	id := value_object.NewCircuitID()
+	rid, _ := value_object.NewRelayID("550e8400-e29b-41d4-a716-446655440000")
+	key, _ := value_object.NewAESKey()
+	nonce, _ := value_object.NewNonce()
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	return entity.NewCircuit(id, []value_object.RelayID{rid}, []value_object.AESKey{key}, []value_object.Nonce{nonce}, priv)
+}
+
+func TestConnectUseCase_Handle(t *testing.T) {
+	cir, err := makeTestCircuitConnect()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	cid := cir.ID().String()
+	payload, _ := value_object.EncodeConnectPayload(&value_object.ConnectPayload{Target: "x"})
+
+	tests := []struct {
+		name  string
+		repo  repository.CircuitRepository
+		tx    *mockTxConnect
+		input usecase.ConnectInput
+		err   bool
+	}{
+		{"ok", &mockRepoConnect{circuit: cir}, &mockTxConnect{}, usecase.ConnectInput{CircuitID: cid, Target: "x"}, false},
+		{"circuit not found", &mockRepoConnect{circuit: nil, err: errors.New("nf")}, &mockTxConnect{}, usecase.ConnectInput{CircuitID: cid}, true},
+		{"bad id", &mockRepoConnect{}, &mockTxConnect{}, usecase.ConnectInput{CircuitID: "bad"}, true},
+		{"tx error", &mockRepoConnect{circuit: cir}, &mockTxConnect{err: errors.New("fail")}, usecase.ConnectInput{CircuitID: cid}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fac := connectFactory{tt.tx}
+			uc := usecase.NewConnectUseCase(tt.repo, fac)
+			_, err := uc.Handle(tt.input)
+			if tt.err {
+				if err == nil {
+					t.Errorf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if tt.tx.cid.String() != cid {
+				t.Errorf("cid not passed")
+			}
+			if tt.input.Target != "" && string(tt.tx.payload) != string(payload) {
+				t.Errorf("payload mismatch")
+			}
+		})
+	}
+}

--- a/internal/usecase/destroy_circuit_usecase_test.go
+++ b/internal/usecase/destroy_circuit_usecase_test.go
@@ -57,6 +57,7 @@ func (m *mockTxDestroy) SendDestroy(c value_object.CircuitID) error {
 	m.destroy = c
 	return m.err
 }
+func (m *mockTxDestroy) SendConnect(value_object.CircuitID, []byte) error { return nil }
 
 type destroyFactory struct{ tx service.CircuitTransmitter }
 

--- a/internal/usecase/send_data_roundtrip_test.go
+++ b/internal/usecase/send_data_roundtrip_test.go
@@ -25,6 +25,7 @@ func (r *recordTx) SendBegin(c value_object.CircuitID, s value_object.StreamID, 
 }
 func (r *recordTx) SendEnd(value_object.CircuitID, value_object.StreamID) error { return nil }
 func (r *recordTx) SendDestroy(value_object.CircuitID) error                    { return nil }
+func (r *recordTx) SendConnect(value_object.CircuitID, []byte) error            { return nil }
 
 type recordFactory struct{ tx *recordTx }
 

--- a/internal/usecase/send_data_usecase_test.go
+++ b/internal/usecase/send_data_usecase_test.go
@@ -36,7 +36,8 @@ func (m *mockTransmitterSend) SendBegin(c value_object.CircuitID, s value_object
 func (m *mockTransmitterSend) SendEnd(c value_object.CircuitID, s value_object.StreamID) error {
 	return nil
 }
-func (m *mockTransmitterSend) SendDestroy(value_object.CircuitID) error { return nil }
+func (m *mockTransmitterSend) SendDestroy(value_object.CircuitID) error         { return nil }
+func (m *mockTransmitterSend) SendConnect(value_object.CircuitID, []byte) error { return nil }
 
 type sendFactory struct{ tx service.CircuitTransmitter }
 

--- a/internal/usecase/service/circuit_transmit_service.go
+++ b/internal/usecase/service/circuit_transmit_service.go
@@ -7,6 +7,7 @@ import "ikedadada/go-ptor/internal/domain/value_object"
 type CircuitTransmitter interface {
 	SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error
 	SendBegin(c value_object.CircuitID, s value_object.StreamID, data []byte) error
+	SendConnect(c value_object.CircuitID, data []byte) error
 	SendEnd(c value_object.CircuitID, s value_object.StreamID) error
 	SendDestroy(c value_object.CircuitID) error
 }

--- a/internal/usecase/shutdown_circuit_usecase_test.go
+++ b/internal/usecase/shutdown_circuit_usecase_test.go
@@ -50,7 +50,8 @@ func (m *mockTransmitterShutdown) SendBegin(value_object.CircuitID, value_object
 func (m *mockTransmitterShutdown) SendData(c value_object.CircuitID, s value_object.StreamID, data []byte) error {
 	return nil
 }
-func (m *mockTransmitterShutdown) SendDestroy(value_object.CircuitID) error { return nil }
+func (m *mockTransmitterShutdown) SendDestroy(value_object.CircuitID) error         { return nil }
+func (m *mockTransmitterShutdown) SendConnect(value_object.CircuitID, []byte) error { return nil }
 
 type shutdownFactory struct{ tx service.CircuitTransmitter }
 


### PR DESCRIPTION
## Summary
- extend `CircuitTransmitter` with `SendConnect`
- implement CONNECT in memory and TCP transmitters
- add `ConnectUseCase` for issuing CONNECT cells
- update client to send CONNECT once for `.ptor` hosts
- document CONNECT and environment variables
- cover new logic with unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868dfe82c64832b8cb25b1b0d1ad26a