### PR TITLE
Add httpdemo service and compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ when processing CONNECT cells. If not set, it falls back to `hidden:5000` (the
 Docker demo value). The older `HIDDEN_ADDR` variable is also checked for
 backward compatibility.
 
+### Hidden service
+
+The hidden service proxies incoming connections to an upstream HTTP server. Use
+the `-http` flag to specify the target address.
+
+The provided `docker compose` configuration starts a small demo server from
+`cmd/httpdemo` and points the hidden service at `httpdemo:8080`. Bring up the
+demo stack with:
+
+```bash
+docker compose up --build
+```
+
+The hidden service will print its `.ptor` address on startup. You can access it
+via the client once the stack is running.
+
 ## Testing
 
 Execute all unit tests with:

--- a/cmd/httpdemo/main.go
+++ b/cmd/httpdemo/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	listen := flag.String("listen", ":8080", "listen address")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("request %s %s", r.Method, r.URL.Path)
+		fmt.Fprintln(w, "hello from httpdemo")
+		log.Printf("response %s %s %d", r.Method, r.URL.Path, http.StatusOK)
+	})
+
+	log.Println("http demo server listening on", *listen)
+	log.Fatal(http.ListenAndServe(*listen, mux))
+}

--- a/compose.yml
+++ b/compose.yml
@@ -51,9 +51,19 @@ services:
     ports:
       - "5003:5000"
       - "8080:8080"
-    command: ["-listen", ":5000"]
+    command: ["-listen", ":5000", "-http", "httpdemo:8080"]
     depends_on:
       - relay3
+      - httpdemo
+    networks:
+      - ptor
+
+  httpdemo:
+    build:
+      context: .
+      dockerfile: docker/httpdemo/Dockerfile
+    ports:
+      - "8082:8080"
     networks:
       - ptor
 

--- a/docker/httpdemo/Dockerfile
+++ b/docker/httpdemo/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM golang:1.24.4-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /httpdemo ./cmd/httpdemo
+
+# Runtime stage
+FROM gcr.io/distroless/static
+COPY --from=build /httpdemo /httpdemo
+EXPOSE 8080
+ENTRYPOINT ["/httpdemo"]


### PR DESCRIPTION
## Summary
- add simple HTTP demo server
- provide Dockerfile for httpdemo
- update docker compose to run httpdemo and wire it to the hidden service
- document how the hidden service proxies to an upstream HTTP server

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868f550feb0832b945fd962048c3560