### PR TITLE
Fix CONNECT handshake race

### DIFF
--- a/internal/usecase/connect_usecase.go
+++ b/internal/usecase/connect_usecase.go
@@ -1,10 +1,7 @@
 package usecase
 
 import (
-	"encoding/binary"
 	"fmt"
-	"io"
-
 	"ikedadada/go-ptor/internal/domain/repository"
 	"ikedadada/go-ptor/internal/domain/value_object"
 	infraSvc "ikedadada/go-ptor/internal/infrastructure/service"
@@ -57,18 +54,6 @@ func (uc *connectUsecaseImpl) Handle(in ConnectInput) (ConnectOutput, error) {
 	tx := uc.factory.New(conn)
 	if err := tx.SendConnect(cid, payload); err != nil {
 		return ConnectOutput{}, err
-	}
-	if conn != nil {
-		var hdr [20]byte
-		if _, err := io.ReadFull(conn, hdr[:]); err != nil {
-			return ConnectOutput{}, err
-		}
-		l := binary.BigEndian.Uint16(hdr[18:20])
-		if l > 0 {
-			if _, err := io.ReadFull(conn, make([]byte, l)); err != nil {
-				return ConnectOutput{}, err
-			}
-		}
 	}
 	return ConnectOutput{Sent: true}, nil
 }

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -295,11 +295,8 @@ func sendCreated(w net.Conn, cid value_object.CircuitID, payload []byte) error {
 }
 
 func sendAck(w net.Conn, cid value_object.CircuitID) error {
-	var buf [20]byte
-	copy(buf[:16], cid.Bytes())
-	binary.BigEndian.PutUint16(buf[18:20], 0)
-	_, err := w.Write(buf[:])
-	if err != nil {
+	c := &value_object.Cell{Cmd: value_object.CmdBeginAck, Version: value_object.Version}
+	if err := forwardCell(w, cid, c); err != nil {
 		return err
 	}
 	log.Printf("response ack cid=%s", cid.String())


### PR DESCRIPTION
## Summary
- forward CONNECT ACK as a full cell
- stop waiting for ACK in ConnectUseCase
- consume ACK cell in ForwardConnectData test
- add ConnectAck test for exit relay

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686908851308832b8df05cc2acd08453