### PR TITLE
Add exit relay selection for hidden services

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ For example, to start the client:
 go run ./cmd/client
 ```
 
-When the client resolves a `.ptor` address, it sends a CONNECT cell once for the
-current circuit before any streams are opened. After the CONNECT succeeds,
-stream data continues to use BEGIN cells as before. The CONNECT payload is onion
-encrypted across all hops so only the exit relay can read it.
+When the client resolves a `.ptor` address, it consults the directory to find
+the designated exit relay for that service. A new circuit is built so this relay
+is the final hop. The client then sends a CONNECT cell once for that circuit
+before any streams are opened. After the CONNECT succeeds, stream data continues
+to use BEGIN cells as before. The CONNECT payload is onion encrypted across all
+hops so only the exit relay can read it.
 
 ### Environment variables
 

--- a/docs/project_plans.md
+++ b/docs/project_plans.md
@@ -754,7 +754,8 @@ func main() {
 1. client は "xxxx...xxxx.ptor" を要求
 2. ptor-client は directory から対応する公開鍵を探す
 3. 対応する relay ノード（exit）と通信確立
-4. 最終 hop が hidden-service に接続
+4. CircuitBuildService へ exit の RelayID を渡して回線を構築
+5. 最終 hop が hidden-service に接続
 
 Directory は .ptor アドレス → Relay ID のマッピングを JSON で持つ。
 

--- a/internal/usecase/build_circuit_usecase.go
+++ b/internal/usecase/build_circuit_usecase.go
@@ -10,7 +10,8 @@ import (
 
 // BuildCircuitInput はユーザーが指定できるパラメータ
 type BuildCircuitInput struct {
-	Hops int // 省略時はデフォルト (3)
+	Hops        int    // 省略時はデフォルト (3)
+	ExitRelayID string // 任意。指定時は最終 hop をこのリレーに固定
 }
 
 // BuildCircuitOutput は UI / API に返すレスポンス
@@ -40,7 +41,15 @@ func NewBuildCircuitUseCase(b service.CircuitBuildService) BuildCircuitUseCase {
 
 func (uc *buildCircuitUseCaseImpl) Handle(in BuildCircuitInput) (BuildCircuitOutput, error) {
 	// hops 引数を service に渡して Circuit を生成
-	cir, err := uc.builder.Build(in.Hops) // Build(hops int) を想定
+	exitID := value_object.RelayID{}
+	if in.ExitRelayID != "" {
+		var err error
+		exitID, err = value_object.NewRelayID(in.ExitRelayID)
+		if err != nil {
+			return BuildCircuitOutput{}, err
+		}
+	}
+	cir, err := uc.builder.Build(in.Hops, exitID)
 	if err != nil {
 		return BuildCircuitOutput{}, err
 	}


### PR DESCRIPTION
## Summary
- allow caller to specify an exit relay when building circuits
- build circuits with the chosen exit hop
- update client to construct circuits per request using directory exit mapping
- extend hidden service end-to-end test
- document new behaviour in README and project plan

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687339ce8bd4832bb80e3180005053d1