### PR TITLE
Fix CREATED header handling

### DIFF
--- a/internal/infrastructure/service/tcp_dialer.go
+++ b/internal/infrastructure/service/tcp_dialer.go
@@ -35,6 +35,9 @@ func (TCPDialer) WaitCreated(conn net.Conn) ([]byte, error) {
 	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
 		return nil, err
 	}
+	if hdr[16] != value_object.CmdCreated || hdr[17] != value_object.Version {
+		return nil, fmt.Errorf("invalid created header")
+	}
 	l := binary.BigEndian.Uint16(hdr[18:20])
 	if l == 0 {
 		return nil, fmt.Errorf("no payload")

--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -337,6 +337,8 @@ func to32(b []byte) [32]byte {
 func sendCreated(w net.Conn, cid value_object.CircuitID, payload []byte) error {
 	var hdr [20]byte
 	copy(hdr[:16], cid.Bytes())
+	hdr[16] = value_object.CmdCreated
+	hdr[17] = value_object.Version
 	binary.BigEndian.PutUint16(hdr[18:20], uint16(len(payload)))
 	if _, err := w.Write(hdr[:]); err != nil {
 		return err

--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -43,6 +43,12 @@ func TestRelayUseCase_ExtendAndForward(t *testing.T) {
 	if _, err := io.ReadFull(up2, hdr); err != nil {
 		t.Fatalf("read header: %v", err)
 	}
+	if hdr[16] != value_object.CmdCreated {
+		t.Fatalf("created cmd %d", hdr[16])
+	}
+	if hdr[17] != value_object.Version {
+		t.Fatalf("created version %d", hdr[17])
+	}
 	l := binary.BigEndian.Uint16(hdr[18:20])
 	body := make([]byte, l)
 	if _, err := io.ReadFull(up2, body); err != nil {
@@ -100,6 +106,12 @@ func TestRelayUseCase_ForwardExtendExisting(t *testing.T) {
 	var respHdr [20]byte
 	if _, err := io.ReadFull(up2, respHdr[:]); err != nil {
 		t.Fatalf("read created hdr: %v", err)
+	}
+	if respHdr[16] != value_object.CmdCreated {
+		t.Fatalf("created cmd %d", respHdr[16])
+	}
+	if respHdr[17] != value_object.Version {
+		t.Fatalf("created version %d", respHdr[17])
 	}
 	l := binary.BigEndian.Uint16(respHdr[18:20])
 	resp := make([]byte, l)


### PR DESCRIPTION
## Summary
- include CmdCreated and Version bytes in the CREATED message header
- validate CREATED header in TCPDialer.WaitCreated
- verify header fields in relay_usecase tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68735c1de5e0832b8abf89a87b64dadc