### PR TITLE
Add ServeConn debug logs

### DIFF
--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -34,7 +34,12 @@ func NewRelayUseCase(priv *rsa.PrivateKey, repo repoif.CircuitTableRepository, c
 }
 
 func (uc *relayUsecaseImpl) ServeConn(c net.Conn) {
-	defer c.Close()
+	log.Printf("ServeConn start local=%s remote=%s", c.LocalAddr(), c.RemoteAddr())
+	defer func() {
+		_ = c.Close()
+		log.Printf("ServeConn stop local=%s remote=%s", c.LocalAddr(), c.RemoteAddr())
+	}()
+
 	for {
 		cid, cell, err := uc.reader.ReadCell(c)
 		if err != nil {


### PR DESCRIPTION
## Summary
- add explicit start/stop logs in `relayUsecaseImpl.ServeConn`
- keep existing error handling

## Testing
- `go test ./...`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735c179cf8832b85c4ff9d65bcf772