### PR TITLE
Add context to AESOpen errors

### DIFF
--- a/internal/usecase/relay_usecase.go
+++ b/internal/usecase/relay_usecase.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -105,7 +106,7 @@ func (uc *relayUsecaseImpl) connect(st *entity.ConnState, cid value_object.Circu
 		uc.ensureServeDown(st)
 		dec, err := uc.crypto.AESOpen(st.Key(), st.Nonce(), cell.Payload)
 		if err != nil {
-			return err
+			return fmt.Errorf("AESOpen connect cid=%s: %w", cid.String(), err)
 		}
 		c := &value_object.Cell{Cmd: value_object.CmdConnect, Version: value_object.Version, Payload: dec}
 		return forwardCell(st.Down(), cid, c)
@@ -114,7 +115,7 @@ func (uc *relayUsecaseImpl) connect(st *entity.ConnState, cid value_object.Circu
 	// exit relay: decode final payload and connect to the hidden service
 	dec, err := uc.crypto.AESOpen(st.Key(), st.Nonce(), cell.Payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("AESOpen connect cid=%s: %w", cid.String(), err)
 	}
 	addr := os.Getenv("PTOR_HIDDEN_ADDR")
 	if addr == "" {
@@ -156,7 +157,7 @@ func (uc *relayUsecaseImpl) connect(st *entity.ConnState, cid value_object.Circu
 func (uc *relayUsecaseImpl) begin(st *entity.ConnState, cid value_object.CircuitID, cell *value_object.Cell) error {
 	dec, err := uc.crypto.AESOpen(st.Key(), st.Nonce(), cell.Payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("AESOpen begin cid=%s: %w", cid.String(), err)
 	}
 
 	if st.IsHidden() {
@@ -221,7 +222,7 @@ func (uc *relayUsecaseImpl) data(st *entity.ConnState, cid value_object.CircuitI
 	}
 	dec, err := uc.crypto.AESOpen(st.Key(), st.Nonce(), p.Data)
 	if err != nil {
-		return err
+		return fmt.Errorf("AESOpen data cid=%s: %w", cid.String(), err)
 	}
 
 	if st.IsHidden() {

--- a/internal/usecase/relay_usecase_test.go
+++ b/internal/usecase/relay_usecase_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -808,4 +809,28 @@ func TestRelayUseCase_MultiHopExtend(t *testing.T) {
 	}
 	upEntry.Close()
 	upClient.Close()
+}
+
+func TestRelayUseCase_AESOpenErrorContext(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	repo := repoimpl.NewCircuitTableRepository(time.Second)
+	crypto := infraSvc.NewCryptoService()
+	uc := usecase.NewRelayUseCase(priv, repo, crypto, infraSvc.NewHandlerCellReader())
+
+	key, _ := value_object.NewAESKey()
+	nonce, _ := value_object.NewNonce()
+	cid := value_object.NewCircuitID()
+	up1, _ := net.Pipe()
+	st := entity.NewConnState(key, nonce, up1, nil)
+	repo.Add(cid, st)
+
+	cell := &value_object.Cell{Cmd: value_object.CmdConnect, Version: value_object.Version, Payload: []byte{1, 2, 3}}
+	err := uc.Handle(up1, cid, cell)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "connect") || !strings.Contains(err.Error(), cid.String()) {
+		t.Fatalf("missing context: %v", err)
+	}
+	st.Up().Close()
 }


### PR DESCRIPTION
## Summary
- clarify AESOpen failures by wrapping them with command name and circuit ID
- add regression test checking error context

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6873ccbc9c0c832b830f49334c01a29b