### PR TITLE
Add environment TTL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ backward compatibility.
 
 Relay connections are kept in an in-memory table. The TTL can be configured
 with the `-ttl` flag when starting the relay. Increase this value when
-troubleshooting long-lived circuits.
+troubleshooting long-lived circuits. A default TTL can also be provided via the
+`PTOR_TTL_SECONDS` environment variable which specifies the number of seconds
+to keep each circuit entry.
 
 Additional logging now records failures when decoding EXTEND payloads,
 connecting to next hops, or forwarding cells so issues can be diagnosed more

--- a/cmd/relay/ttl_env_test.go
+++ b/cmd/relay/ttl_env_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDefaultTTLFromEnv(t *testing.T) {
+	os.Setenv("PTOR_TTL_SECONDS", "10")
+	defer os.Unsetenv("PTOR_TTL_SECONDS")
+	if got := defaultTTL(); got != 10*time.Second {
+		t.Fatalf("expected 10s, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- allow PTOR_TTL_SECONDS to override relay TTL flag default
- document new env var in README
- test TTL parsing from environment

## Testing
- `go test ./cmd/relay -run TestDefaultTTLFromEnv -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6873ccbf15a0832bb2e8497da2a53e8e