### PR TITLE
Standardize UseCase naming convention to follow Go and Clean Architec…

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -46,10 +46,10 @@ func main() {
 
 	factory := service.TCPMessagingServiceFactory{}
 	openUC := usecase.NewOpenStreamUseCase(circuitRepository)
-	closeUC := usecase.NewCloseStreamUsecase(circuitRepository, factory)
-	sendUC := usecase.NewSendDataUsecase(circuitRepository, factory, cryptoSvc)
+	closeUC := usecase.NewCloseStreamUseCase(circuitRepository, factory)
+	sendUC := usecase.NewSendDataUseCase(circuitRepository, factory, cryptoSvc)
 	connectUC := usecase.NewSendConnectUseCase(circuitRepository, factory, cryptoSvc)
-	endUC := usecase.NewHandleEndUsecase(circuitRepository)
+	endUC := usecase.NewHandleEndUseCase(circuitRepository)
 
 	// Create SOCKS5 controller
 	socks5Controller := handler.NewSOCKS5Controller(

--- a/cmd/client/usecase/close_stream_usecase.go
+++ b/cmd/client/usecase/close_stream_usecase.go
@@ -24,17 +24,17 @@ type CloseStreamUseCase interface {
 	Handle(in CloseStreamInput) (CloseStreamOutput, error)
 }
 
-type closeStreamUsecaseImpl struct {
+type closeStreamUseCaseImpl struct {
 	cr      repository.CircuitRepository
 	factory service.MessagingServiceFactory
 }
 
-// NewCloseStreamUsecase creates a use case for closing streams.
-func NewCloseStreamUsecase(cr repository.CircuitRepository, f service.MessagingServiceFactory) CloseStreamUseCase {
-	return &closeStreamUsecaseImpl{cr: cr, factory: f}
+// NewCloseStreamUseCase creates a use case for closing streams.
+func NewCloseStreamUseCase(cr repository.CircuitRepository, f service.MessagingServiceFactory) CloseStreamUseCase {
+	return &closeStreamUseCaseImpl{cr: cr, factory: f}
 }
 
-func (uc *closeStreamUsecaseImpl) Handle(in CloseStreamInput) (CloseStreamOutput, error) {
+func (uc *closeStreamUseCaseImpl) Handle(in CloseStreamInput) (CloseStreamOutput, error) {
 	cid, err := vo.CircuitIDFrom(in.CircuitID)
 	if err != nil {
 		return CloseStreamOutput{}, err

--- a/cmd/client/usecase/close_stream_usecase_test.go
+++ b/cmd/client/usecase/close_stream_usecase_test.go
@@ -79,7 +79,7 @@ func TestCloseStreamInteractor_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := usecase.NewCloseStreamUsecase(tt.repo, tt.fac)
+			uc := usecase.NewCloseStreamUseCase(tt.repo, tt.fac)
 			_, err := uc.Handle(tt.input)
 			if tt.expectsErr && err == nil {
 				t.Errorf("expected error")
@@ -93,7 +93,7 @@ func TestCloseStreamInteractor_Handle(t *testing.T) {
 	t.Run("control end on last stream", func(t *testing.T) {
 		tx := &mockTransmitterClose{}
 		repo := &mockCircuitRepoClose{circuit: circuit}
-		uc := usecase.NewCloseStreamUsecase(repo, closeFactory{tx})
+		uc := usecase.NewCloseStreamUseCase(repo, closeFactory{tx})
 		if _, err := uc.Handle(usecase.CloseStreamInput{CircuitID: circuit.ID().String(), StreamID: st.ID.UInt16()}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/client/usecase/handle_end_usecase.go
+++ b/cmd/client/usecase/handle_end_usecase.go
@@ -23,16 +23,16 @@ type HandleEndUseCase interface {
 	Handle(in HandleEndInput) (HandleEndOutput, error)
 }
 
-type handleEndUsecaseImpl struct {
+type handleEndUseCaseImpl struct {
 	repo repository.CircuitRepository
 }
 
-// NewHandleEndUsecase creates a use case for handling END cells.
-func NewHandleEndUsecase(r repository.CircuitRepository) HandleEndUseCase {
-	return &handleEndUsecaseImpl{repo: r}
+// NewHandleEndUseCase creates a use case for handling END cells.
+func NewHandleEndUseCase(r repository.CircuitRepository) HandleEndUseCase {
+	return &handleEndUseCaseImpl{repo: r}
 }
 
-func (uc *handleEndUsecaseImpl) Handle(in HandleEndInput) (HandleEndOutput, error) {
+func (uc *handleEndUseCaseImpl) Handle(in HandleEndInput) (HandleEndOutput, error) {
 	cid, err := vo.CircuitIDFrom(in.CircuitID)
 	if err != nil {
 		return HandleEndOutput{}, fmt.Errorf("parse circuit id: %w", err)

--- a/cmd/client/usecase/handle_end_usecase_test.go
+++ b/cmd/client/usecase/handle_end_usecase_test.go
@@ -42,7 +42,7 @@ func makeCircuitForEnd() (*entity.Circuit, vo.StreamID, error) {
 	return cir, st.ID, nil
 }
 
-func TestHandleEndUsecase(t *testing.T) {
+func TestHandleEndUseCase(t *testing.T) {
 	cir, sid, err := makeCircuitForEnd()
 	if err != nil {
 		t.Fatalf("setup: %v", err)
@@ -51,7 +51,7 @@ func TestHandleEndUsecase(t *testing.T) {
 
 	t.Run("stream", func(t *testing.T) {
 		repo := &mockRepoEnd{cir: cir}
-		uc := usecase.NewHandleEndUsecase(repo)
+		uc := usecase.NewHandleEndUseCase(repo)
 		out, err := uc.Handle(usecase.HandleEndInput{CircuitID: cid, StreamID: sid.UInt16()})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -63,7 +63,7 @@ func TestHandleEndUsecase(t *testing.T) {
 
 	t.Run("circuit", func(t *testing.T) {
 		repo := &mockRepoEnd{cir: cir}
-		uc := usecase.NewHandleEndUsecase(repo)
+		uc := usecase.NewHandleEndUseCase(repo)
 		out, err := uc.Handle(usecase.HandleEndInput{CircuitID: cid, StreamID: 0})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -78,7 +78,7 @@ func TestHandleEndUsecase(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		repo := &mockRepoEnd{cir: nil, find: repository.ErrNotFound}
-		uc := usecase.NewHandleEndUsecase(repo)
+		uc := usecase.NewHandleEndUseCase(repo)
 		_, err := uc.Handle(usecase.HandleEndInput{CircuitID: cid, StreamID: sid.UInt16()})
 		if err == nil {
 			t.Errorf("expected error")
@@ -87,7 +87,7 @@ func TestHandleEndUsecase(t *testing.T) {
 
 	t.Run("bad id", func(t *testing.T) {
 		repo := &mockRepoEnd{}
-		uc := usecase.NewHandleEndUsecase(repo)
+		uc := usecase.NewHandleEndUseCase(repo)
 		_, err := uc.Handle(usecase.HandleEndInput{CircuitID: "bad", StreamID: 1})
 		if err == nil {
 			t.Errorf("expected error")

--- a/cmd/client/usecase/send_connect_usecase.go
+++ b/cmd/client/usecase/send_connect_usecase.go
@@ -25,7 +25,7 @@ type SendConnectUseCase interface {
 	Handle(in SendConnectInput) (SendConnectOutput, error)
 }
 
-type sendConnectUsecaseImpl struct {
+type sendConnectUseCaseImpl struct {
 	repo    repository.CircuitRepository
 	factory service.MessagingServiceFactory
 	crypto  service.CryptoService
@@ -33,10 +33,10 @@ type sendConnectUsecaseImpl struct {
 
 // NewSendConnectUseCase creates a use case for CONNECT cells.
 func NewSendConnectUseCase(r repository.CircuitRepository, f service.MessagingServiceFactory, c service.CryptoService) SendConnectUseCase {
-	return &sendConnectUsecaseImpl{repo: r, factory: f, crypto: c}
+	return &sendConnectUseCaseImpl{repo: r, factory: f, crypto: c}
 }
 
-func (uc *sendConnectUsecaseImpl) Handle(in SendConnectInput) (SendConnectOutput, error) {
+func (uc *sendConnectUseCaseImpl) Handle(in SendConnectInput) (SendConnectOutput, error) {
 	cid, err := vo.CircuitIDFrom(in.CircuitID)
 	if err != nil {
 		return SendConnectOutput{}, fmt.Errorf("parse circuit id: %w", err)

--- a/cmd/client/usecase/send_data_usecase.go
+++ b/cmd/client/usecase/send_data_usecase.go
@@ -32,8 +32,8 @@ type sendDataUseCaseImpl struct {
 	crypto  service.CryptoService
 }
 
-// NewSendDataUsecase returns a use case for sending data cells.
-func NewSendDataUsecase(cr repository.CircuitRepository, f service.MessagingServiceFactory, c service.CryptoService) SendDataUseCase {
+// NewSendDataUseCase returns a use case for sending data cells.
+func NewSendDataUseCase(cr repository.CircuitRepository, f service.MessagingServiceFactory, c service.CryptoService) SendDataUseCase {
 	return &sendDataUseCaseImpl{cr: cr, factory: f, crypto: c}
 }
 

--- a/cmd/client/usecase/send_data_usecase_test.go
+++ b/cmd/client/usecase/send_data_usecase_test.go
@@ -73,7 +73,7 @@ func TestSendDataInteractor_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := usecase.NewSendDataUsecase(tt.repo, tt.fac, service.NewCryptoService())
+			uc := usecase.NewSendDataUseCase(tt.repo, tt.fac, service.NewCryptoService())
 			_, err := uc.Handle(tt.input)
 			if tt.expectsErr && err == nil {
 				t.Errorf("expected error")
@@ -129,7 +129,7 @@ func TestSendData_OnionRoundTrip(t *testing.T) {
 	repo := &mockCircuitRepoSend{circuit: cir}
 	tx := &recordTx{}
 	crypto := service.NewCryptoService()
-	uc := usecase.NewSendDataUsecase(repo, recordFactory{tx}, crypto)
+	uc := usecase.NewSendDataUseCase(repo, recordFactory{tx}, crypto)
 	data := []byte("hello")
 	if _, err := uc.Handle(usecase.SendDataInput{CircuitID: cir.ID().String(), StreamID: st.ID.UInt16(), Data: data}); err != nil {
 		t.Fatalf("handle: %v", err)
@@ -174,7 +174,7 @@ func TestSendData_BeginRoundTrip(t *testing.T) {
 	repo := &mockCircuitRepoSend{circuit: cir}
 	tx := &recordTx{}
 	crypto := service.NewCryptoService()
-	uc := usecase.NewSendDataUsecase(repo, recordFactory{tx}, crypto)
+	uc := usecase.NewSendDataUseCase(repo, recordFactory{tx}, crypto)
 	payload, _ := vo.EncodeBeginPayload(&vo.BeginPayload{StreamID: st.ID.UInt16(), Target: "example.com:80"})
 	if _, err := uc.Handle(usecase.SendDataInput{CircuitID: cir.ID().String(), StreamID: st.ID.UInt16(), Data: payload, Cmd: vo.CmdBegin}); err != nil {
 		t.Fatalf("handle: %v", err)


### PR DESCRIPTION
…ture best practices

- Rename impl structs: sendConnectUsecaseImpl → sendConnectUseCaseImpl, etc.
- Rename constructors: NewCloseStreamUsecase → NewCloseStreamUseCase, etc.
- Rename test functions: TestHandleEndUsecase → TestHandleEndUseCase
- Update all references in main.go and test files

This change aligns with:
- Go naming conventions (HTTPClient, JSONDecoder pattern)
- Clean Architecture terminology ("Use Case" as two words)
- Improved code readability and consistency

🤖 Generated with [Claude Code](https://claude.ai/code)